### PR TITLE
Actually lookup the card token on customer update

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -60,18 +60,18 @@ module StripeMock
         route =~ method_url
         assert_existance :customer, $1, customers[$1]
 
-        card_id = new_id('cc') if params.delete(:card)
         cus = customers[$1] ||= Data.mock_customer([], :id => $1)
         cus.merge!(params)
 
-        if card_id
-          new_card = Data.mock_card(id: card_id, customer: cus[:id])
+        if params[:card]
+          new_card = get_card_by_token(params.delete(:card))
 
           if cus[:cards][:count] == 0
             cus[:cards][:count] += 1
           else
             cus[:cards][:data].delete_if {|card| card[:id] == cus[:default_card]}
           end
+
           cus[:cards][:data] << new_card
           cus[:default_card] = new_card[:id]
         end


### PR DESCRIPTION
I needed this because I want to test that I'm actually updating the card. Didn't bother adding any test for this because..
1. I know it's working as I expected in my actual tests for my app
2. this doesn't break the existing tests
3. at worst this is just replacing a random behaviour with another random behaviour
4. not sure if you want to mix in the token generation/lookup stuff in the customers tests
