### PR TITLE
Allow existing charge to be captured

### DIFF
--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -104,4 +104,18 @@ shared_examples 'Charge API' do
     end
   end
 
+  describe "two-step charge (auth, then capture)" do
+    it "changes captured status upon #capture" do
+      charge = Stripe::Charge.create({
+        amount: 777,
+        currency: 'USD',
+        card: 'card_token_abc',
+        capture: false
+      })
+
+      ret = charge.capture
+      expect(charge.captured).to be_true
+      expect ret.to_eq charge
+    end
+  end
 end


### PR DESCRIPTION
This PR is not ready for integration, but I thought I would submit the spec for the sake of clarifying what I'm trying to accomplish.

Stripe's [documentation](https://stripe.com/docs/api/ruby#charge_capture) provides the following example for capturing an existing charge:

``` ruby
ch = Stripe::Charge.retrieve("ch_2KqJkK1jF4deHa")
ch.capture
```

This method will return the original charge hash, but with the `'captured'` key set to `true`.

I've been trying to implement this behavior in stripe-ruby-mock, but I can't seem to find the right hook to trigger any behavior that I implement. I think I'm missing something very basic. So far I've tried imitating the code for Customer#update_subscription, and other instance methods, but I'll spare you further details.

Where should I start to intercept the Charge#capture method?
