### PR TITLE
fix refund return value

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -78,7 +78,8 @@ module StripeMock
             object: "refund",
             balance_transaction: "txn_2dyYXXP90MN26R"
           }
-        ]
+        ],
+        amount_refunded: params[:amount]
       })
     end
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -133,5 +133,6 @@ shared_examples 'Charge API' do
 
     expect(charge.refunded).to eq(true)
     expect(charge.refunds.first.amount).to eq(999)
+    expect(charge.amount_refunded).to eq(999)
   end
 end


### PR DESCRIPTION
per https://stripe.com/docs/api/curl#refund_charge the "amount_refunded" value was missing.
