### PR TITLE
Allow passing a card as a parameter when updating a plan

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -31,6 +31,12 @@ module StripeMock
         plan = plans[ params[:plan] ]
         assert_existance :plan, params[:plan], plan
 
+        if params[:card]
+          new_card = get_card_by_token(params.delete(:card))
+          add_card_to_customer(new_card, customer)
+          customer[:default_card] = new_card[:id]
+        end
+
         # Ensure customer has card to charge if plan has no trial and is not free
         if customer[:default_card].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
           raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -203,6 +203,19 @@ shared_examples 'Customer API' do
     expect(customer.deleted).to be_true
   end
 
+  it "sets card" do
+    plan = Stripe::Plan.create(id: 'small')
+    customer = Stripe::Customer.create(id: 'test_customer_sub')
+    customer.update_subscription(card: 'tk', :plan => 'small')
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+
+    expect(customer.cards.count).to eq(1)
+    expect(customer.cards.data.length).to eq(1)
+    expect(customer.default_card).to_not be_nil
+    expect(customer.default_card).to eq customer.cards.data.first.id
+  end
+
   context "With strict mode toggled off" do
 
     before { StripeMock.toggle_strict(false) }


### PR DESCRIPTION
https://github.com/rebelidealist/stripe-ruby-mock/issues/31
