### PR TITLE
Set status and cancel_at_period_end instead of deleting a subscription.

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -68,12 +68,19 @@ module StripeMock
         sub = customer[:subscription]
         assert_existance nil, nil, sub, "No active subscription for customer: #{$1}"
 
-        customer[:subscription] = nil
-
         plan = plans[ sub[:plan][:id] ]
         assert_existance :plan, params[:plan], plan
 
-        Data.mock_delete_subscription(id: sub[:id])
+        if params[:at_period_end] == true
+          status = 'active'
+          cancel_at_period_end = true
+        else
+          status = 'canceled'
+          cancel_at_period_end = false
+        end
+
+        sub = Data.mock_subscription id: sub[:id], plan: plan, customer: $1, status: status, cancel_at_period_end: cancel_at_period_end
+        customer[:subscription] = sub
       end
 
       def update_customer(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -201,15 +201,33 @@ shared_examples 'Customer API' do
   end
 
   it "cancels a stripe customer's subscription" do
-    plan = Stripe::Plan.create(id: 'the truth')
+    Stripe::Plan.create(id: 'the truth')
     customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk')
     sub = customer.update_subscription({ :plan => 'the truth' })
 
     result = customer.cancel_subscription
-    expect(result.deleted).to eq(true)
+    expect(result.status).to eq('canceled')
+    expect(result.cancel_at_period_end).to be_false
     expect(result.id).to eq(sub.id)
+
     customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.subscription).to be_nil
+    expect(customer.subscription).to_not be_nil
+    expect(customer.subscription.id).to eq(result.id)
+  end
+
+  it "cancels a stripe customer's subscription at period end" do
+    Stripe::Plan.create(id: 'the truth')
+    customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk')
+    sub = customer.update_subscription({ :plan => 'the truth' })
+
+    result = customer.cancel_subscription(at_period_end: true)
+    expect(result.status).to eq('active')
+    expect(result.cancel_at_period_end).to be_true
+    expect(result.id).to eq(sub.id)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.subscription).to_not be_nil
+    expect(customer.subscription.id).to eq(result.id)
   end
 
   it "cannot update to a plan that does not exist" do


### PR DESCRIPTION
Fix for issue #44
