### PR TITLE
Added update card method and specs

### DIFF
--- a/lib/stripe_mock/request_handlers/cards.rb
+++ b/lib/stripe_mock/request_handlers/cards.rb
@@ -6,6 +6,7 @@ module StripeMock
         klass.add_handler 'post /v1/customers/(.*)/cards', :create_card
         klass.add_handler 'get /v1/customers/(.*)/cards/(.*)', :retrieve_card
         klass.add_handler 'delete /v1/customers/(.*)/cards/(.*)', :delete_card
+        klass.add_handler 'post /v1/customers/(.*)/cards/(.*)', :update_card
       end
 
       def create_card(route, method_url, params, headers)
@@ -39,6 +40,17 @@ module StripeMock
         customer[:cards][:data].reject!{|cc| 
           cc[:id] == card[:id]
         }
+        card
+      end
+
+      def update_card(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+        card = get_customer_card(customer, $2)
+        assert_existance :card, $2, card
+        card.merge!(params)
         card
       end
 

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -71,4 +71,25 @@ shared_examples 'Card API' do
     it "updates the default card if deleted"
 
   end
+
+  context "update card" do
+    let!(:customer) { Stripe::Customer.create(id: 'test_customer_sub') }
+    let!(:card_token) { StripeMock.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
+    let!(:card) { customer.cards.create(card: card_token) }
+
+    it "updates the card" do
+      exp_month = 10
+      exp_year = 2098
+
+      card.exp_month = exp_month
+      card.exp_year = exp_year
+      card.save
+
+      retrieved = customer.cards.retrieve(card.id)
+
+      expect(retrieved.exp_month).to eq(exp_month)
+      expect(retrieved.exp_year).to eq(exp_year)
+    end
+  end
+
 end


### PR DESCRIPTION
Partially closes https://github.com/rebelidealist/stripe-ruby-mock/issues/48

Closing https://github.com/rebelidealist/stripe-ruby-mock/pull/50 in favor of new pull request on separate branch.

The spec fails on the server side. Passes fine for the Instance. Not sure what is going wrong.
