### PR TITLE
Added support for multiple subscriptions

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -37,6 +37,7 @@ require 'stripe_mock/request_handlers/invoices.rb'
 require 'stripe_mock/request_handlers/invoice_items.rb'
 require 'stripe_mock/request_handlers/plans.rb'
 require 'stripe_mock/request_handlers/recipients.rb'
+require 'stripe_mock/request_handlers/subscriptions.rb'
 require 'stripe_mock/request_handlers/tokens.rb'
 require 'stripe_mock/instance'
 

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -12,7 +12,6 @@ module StripeMock
         id: cus_id,
         livemode: false,
         delinquent: false,
-        subscription: nil,
         discount: nil,
         account_balance: 0,
         cards: {
@@ -152,6 +151,7 @@ module StripeMock
         :current_period_start => 1308595038,
         :cancel_at_period_end => false,
         :canceled_at => nil,
+        :ended_at => nil,
         :start => 1308595038,
         :object => "subscription",
         :trial_start => 1308595038,
@@ -219,6 +219,15 @@ module StripeMock
         :object => 'list',
         :url => '/v1/invoices?customer=test_customer'
       }
+    end
+
+    def self.mock_subscriptions_array(params={})
+      {
+        :data => [],
+        :count => 0,
+        :object => "list",
+        :url => '/v1/customers/test_customer/subscriptions',
+      }.merge(params)
     end
 
     def self.mock_plan(params={})

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -17,6 +17,7 @@ module StripeMock
 
     include StripeMock::RequestHandlers::Charges
     include StripeMock::RequestHandlers::Cards
+    include StripeMock::RequestHandlers::Subscriptions # must be before Customers
     include StripeMock::RequestHandlers::Customers
     include StripeMock::RequestHandlers::Events
     include StripeMock::RequestHandlers::Invoices
@@ -27,7 +28,7 @@ module StripeMock
 
 
     attr_reader :bank_tokens, :charges, :customers, :events,
-                :invoices, :plans, :recipients
+                :invoices, :plans, :recipients, :subscriptions
 
     attr_accessor :error_queue, :debug, :strict
 
@@ -40,6 +41,7 @@ module StripeMock
       @invoices = {}
       @plans = {}
       @recipients = {}
+      @subscriptions = {}
 
       @debug = false
       @error_queue = ErrorQueue.new
@@ -126,6 +128,17 @@ module StripeMock
       cus[:cards][:data] << card
 
       card
+    end
+
+    def get_customer_subscription(customer, sub_id)
+      customer[:subscriptions][:data].find{|sub| sub[:id] == sub_id }
+    end
+
+    def add_subscription_to_customer(subscription, cus)
+      subscription[:customer] = cus[:id]
+      cus[:subscriptions] = Data.mock_subscriptions_array(url: "/v1/customers/#{cus[:id]}/subscriptions") unless cus[:subscriptions]
+      cus[:subscriptions][:count] = (cus[:subscriptions][:count] ? cus[:subscriptions][:count]+1 : 1 )
+      cus[:subscriptions][:data] << subscription
     end
 
     private

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -4,8 +4,6 @@ module StripeMock
 
       def Customers.included(klass)
         klass.add_handler 'post /v1/customers',                     :new_customer
-        klass.add_handler 'post /v1/customers/(.*)/subscription',   :update_subscription
-        klass.add_handler 'delete /v1/customers/(.*)/subscription', :cancel_subscription
         klass.add_handler 'post /v1/customers/(.*)',                :update_customer
         klass.add_handler 'get /v1/customers/(.*)',                 :get_customer
         klass.add_handler 'delete /v1/customers/(.*)',              :delete_customer
@@ -20,6 +18,9 @@ module StripeMock
           params[:default_card] = cards.first[:id]
         end
 
+        params[:subscriptions] = Data.mock_subscriptions_array(url: "/v1/customers/#{params[:id]}/subscriptions")
+        customers[ params[:id] ] = Data.mock_customer(cards, params)
+
         if params[:plan]
           plan = plans[ params[:plan] ]
           assert_existance :plan, params[:plan], plan
@@ -29,58 +30,10 @@ module StripeMock
           end
 
           sub = Data.mock_subscription id: new_id('su'), plan: plan, customer: params[:id]
-          params[:subscription] = sub
+          add_subscription_to_customer(sub, customers[params[:id]] )
         end
 
-        customers[ params[:id] ] = Data.mock_customer(cards, params)
-      end
-
-      def update_subscription(route, method_url, params, headers)
-        route =~ method_url
-
-        customer = customers[$1]
-        assert_existance :customer, $1, customer
-
-        plan = plans[ params[:plan] ]
-        assert_existance :plan, params[:plan], plan
-
-        if params[:card]
-          new_card = get_card_by_token(params.delete(:card))
-          add_card_to_customer(new_card, customer)
-          customer[:default_card] = new_card[:id]
-        end
-
-        # Ensure customer has card to charge if plan has no trial and is not free
-        if customer[:default_card].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
-          raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
-        end
-
-        sub = Data.mock_subscription id: new_id('su'), plan: plan, customer: $1
-        customer[:subscription] = sub
-      end
-
-      def cancel_subscription(route, method_url, params, headers)
-        route =~ method_url
-
-        customer = customers[$1]
-        assert_existance :customer, $1, customer
-
-        sub = customer[:subscription]
-        assert_existance nil, nil, sub, "No active subscription for customer: #{$1}"
-
-        plan = plans[ sub[:plan][:id] ]
-        assert_existance :plan, params[:plan], plan
-
-        if params[:at_period_end] == true
-          status = 'active'
-          cancel_at_period_end = true
-        else
-          status = 'canceled'
-          cancel_at_period_end = false
-        end
-
-        sub = Data.mock_subscription id: sub[:id], plan: plan, customer: $1, status: status, cancel_at_period_end: cancel_at_period_end
-        customer[:subscription] = sub
+        customers[ params[:id] ]
       end
 
       def update_customer(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -1,0 +1,129 @@
+module StripeMock
+  module RequestHandlers
+    module Subscriptions
+
+      def Subscriptions.included(klass)
+        klass.add_handler 'get /v1/customers/(.*)/subscriptions', :retrieve_subscriptions
+        klass.add_handler 'post /v1/customers/(.*)/subscriptions', :create_subscription
+        klass.add_handler 'get /v1/customers/(.*)/subscriptions/(.*)', :retrieve_subscription
+        klass.add_handler 'post /v1/customers/(.*)/subscriptions/(.*)', :update_subscription
+        klass.add_handler 'delete /v1/customers/(.*)/subscriptions/(.*)', :cancel_subscription
+      end
+
+      def create_subscription(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+
+        plan = plans[params[:plan]]
+        assert_existance :plan, params[:plan], plan
+
+        # Ensure customer has card to charge if plan has no trial and is not free
+        verify_card_present(customer, plan)
+
+        subscription = Data.mock_subscription id: new_id('su'), plan: plan, customer: customer
+        add_subscription_to_customer(subscription, customer)
+
+        # oddly, subscription returned from 'create_subscription' does not expand plan
+        subscription.merge(plan: params[:plan])
+      end
+
+      def retrieve_subscription(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+        subscription = get_customer_subscription(customer, $2)
+        assert_existance :subscription, $2, subscription
+
+        subscription
+      end
+
+      def retrieve_subscriptions(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+
+        subscription_list = Data.mock_subscriptions_array url: "/v1/customers/#{customer[:id]}/subscriptions", count: customer[:subscriptions][:data].length
+        customer.subscriptions.each do |subscription|
+          subscription_list[:data] << subscription
+        end
+        subscription_list
+      end
+
+      def update_subscription(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+        subscription = get_customer_subscription(customer, $2)
+        assert_existance :subscription, $2, subscription
+
+        if params[:card]
+          new_card = get_card_by_token(params.delete(:card))
+          add_card_to_customer(new_card, customer)
+          customer[:default_card] = new_card[:id]
+        end
+
+        # expand the plan for addition to the customer object
+        if params[:plan]
+          plan_name = params[:plan]
+          plan = plans[plan_name]
+          assert_existance :plan, params[:plan], plan
+          params[:plan] = plan
+        end
+
+        # Ensure customer has card to charge if plan has no trial and is not free
+        verify_card_present(customer, plan)
+
+        subscription.merge!(params)
+
+        # delete the old subscription, replace with the new subscription
+        customer[:subscriptions][:data].reject! { |sub| sub[:id] == subscription[:id] }
+        customer[:subscriptions][:data] << subscription
+
+        # oddly, subscription returned from 'create_subscription' does not expand plan
+        subscription.merge(plan: plan_name)
+      end
+
+      def cancel_subscription(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+        subscription = get_customer_subscription(customer, $2)
+        assert_existance :subscription, $2, subscription
+
+        if params[:at_period_end] == true
+          status = 'active'
+          cancel_at_period_end = true
+          ended_at = nil
+        else
+          status = 'canceled'
+          cancel_at_period_end = false
+          ended_at = Time.now.to_i
+        end
+
+        subscription.merge!(status: status, cancel_at_period_end: cancel_at_period_end, canceled_at: Time.now.to_i, ended_at: ended_at )
+
+        customer[:subscriptions][:data].reject!{|sub|
+          sub[:id] == subscription[:id]
+        }
+
+        customer[:subscriptions][:data] << subscription
+        subscription
+      end
+
+      private
+
+      def verify_card_present(customer, plan)
+        if customer[:default_card].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
+          raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -39,9 +39,12 @@ shared_examples 'Customer API' do
     customer = Stripe::Customer.create(id: 'test_cus_plan', card: 'tk', :plan => 'silver')
 
     customer = Stripe::Customer.retrieve('test_cus_plan')
-    expect(customer.subscription).to_not be_nil
-    expect(customer.subscription.plan.id).to eq('silver')
-    expect(customer.subscription.customer).to eq(customer.id)
+    expect(customer.subscriptions.count).to eq(1)
+    expect(customer.subscriptions.data.length).to eq(1)
+
+    expect(customer.subscriptions).to_not be_nil
+    expect(customer.subscriptions.first.plan.id).to eq('silver')
+    expect(customer.subscriptions.first.customer).to eq(customer.id)
   end
 
   it 'cannot create a customer with a plan that does not exist' do
@@ -90,7 +93,8 @@ shared_examples 'Customer API' do
     expect(customer.id).to eq(original.id)
     expect(customer.email).to eq(original.email)
     expect(customer.default_card).to eq(original.default_card)
-    expect(customer.subscription).to be_nil
+    expect(customer.subscriptions.count).to eq(0)
+    expect(customer.subscriptions.data).to be_empty
   end
 
   it "cannot retrieve a customer that doesn't exist" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -2,120 +2,330 @@ require 'spec_helper'
 
 shared_examples 'Customer Subscriptions' do
 
-  it "updates a stripe customer's subscription" do
-    plan = Stripe::Plan.create(id: 'silver')
-    customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk')
-    sub = customer.update_subscription({ :plan => 'silver' })
+  context "creating a new subscription" do
+    it "adds a new subscription to customer with none" do
+      plan = Stripe::Plan.create(id: 'silver', name: 'Silver Plan', amount: 4999)
+      customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk')
 
-    expect(sub.object).to eq('subscription')
-    expect(sub.plan.id).to eq('silver')
-    expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
 
-    customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.subscription).to_not be_nil
-    expect(customer.subscription.id).to eq(sub.id)
-    expect(customer.subscription.plan.id).to eq('silver')
-    expect(customer.subscription.customer).to eq(customer.id)
+      sub = customer.subscriptions.create({ :plan => 'silver' })
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('silver')
+
+      customer = Stripe::Customer.retrieve('test_customer_sub')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+
+    end
+
+    it "adds additional subscription to customer with existing subscription" do
+      silver =  Stripe::Plan.create(id: 'silver')
+      gold =    Stripe::Plan.create(id: 'gold')
+      customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk', plan: 'gold')
+
+      sub = customer.subscriptions.create({ :plan => 'silver' })
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('silver')
+
+      customer = Stripe::Customer.retrieve('test_customer_sub')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(2)
+      expect(customer.subscriptions.data.length).to eq(2)
+
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(gold.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+
+      expect(customer.subscriptions.data.last.id).to eq(sub.id)
+      expect(customer.subscriptions.data.last.plan.to_hash).to eq(silver.to_hash)
+      expect(customer.subscriptions.data.last.customer).to eq(customer.id)
+    end
+
+    it "throws an error when plan does not exist" do
+      customer = Stripe::Customer.create(id: 'cardless')
+
+      expect { customer.subscriptions.create({ :plan => 'gazebo' }) }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.http_status).to eq(404)
+        expect(e.message).to_not be_nil
+      }
+
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+    end
+
+    it "throws an error when subscribing a customer with no card" do
+      plan = Stripe::Plan.create(id: 'enterprise', amount: 499)
+      customer = Stripe::Customer.create(id: 'cardless')
+
+      expect { customer.subscriptions.create({ :plan => 'enterprise' }) }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.http_status).to eq(400)
+        expect(e.message).to_not be_nil
+      }
+
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+    end
+
+    it "subscribes a customer with no card to a plan with a free trial" do
+      plan = Stripe::Plan.create(id: 'trial', amount: 999, trial_period_days: 14)
+      customer = Stripe::Customer.create(id: 'cardless')
+
+      sub = customer.subscriptions.create({ :plan => 'trial' })
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('trial')
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+    end
+
+    it "subscribes a customer with no card to a free plan" do
+      plan = Stripe::Plan.create(id: 'free_tier', amount: 0)
+      customer = Stripe::Customer.create(id: 'cardless')
+
+      sub = customer.subscriptions.create({ :plan => 'free_tier' })
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('free_tier')
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+    end
   end
 
-  it "throws an error when subscribing a customer with no card" do
-    plan = Stripe::Plan.create(id: 'enterprise', amount: 499)
-    customer = Stripe::Customer.create(id: 'cardless')
+  context "updating a subscription" do
 
-    expect { customer.update_subscription({ :plan => 'enterprise' }) }.to raise_error {|e|
-      expect(e).to be_a Stripe::InvalidRequestError
-      expect(e.http_status).to eq(400)
-      expect(e.message).to_not be_nil
-    }
+    it "updates a stripe customer's existing subscription" do
+      silver = Stripe::Plan.create(id: 'silver')
+      gold = Stripe::Plan.create(id: 'gold')
+      customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk', plan: 'silver')
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      sub.plan = 'gold'
+      sub.save
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('gold')
+
+      customer = Stripe::Customer.retrieve('test_customer_sub')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(gold.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+    end
+
+    it "throws an error when plan does not exist" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      customer = Stripe::Customer.create(id: 'cardless', plan: 'free')
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      sub.plan = 'gazebo'
+
+      expect { sub.save }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.http_status).to eq(404)
+        expect(e.message).to_not be_nil
+      }
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(free.to_hash)
+    end
+
+    it "throws an error when subscription does not exist" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      customer = Stripe::Customer.create(id: 'cardless', plan: 'free')
+
+      expect { customer.subscriptions.retrieve("gazebo") }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.http_status).to eq(404)
+        expect(e.message).to_not be_nil
+      }
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(free.to_hash)
+    end
+
+    it "throws an error when updating a customer with no card" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      paid = Stripe::Plan.create(id: 'enterprise', amount: 499)
+      customer = Stripe::Customer.create(id: 'cardless', plan: 'free')
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      sub.plan = 'enterprise'
+
+      expect { sub.save }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.http_status).to eq(400)
+        expect(e.message).to_not be_nil
+      }
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(free.to_hash)
+    end
+
+    it "updates a customer with no card to a plan with a free trial" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      trial = Stripe::Plan.create(id: 'trial', amount: 999, trial_period_days: 14)
+      customer = Stripe::Customer.create(id: 'cardless', plan: 'free')
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      sub.plan = 'trial'
+      sub.save
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('trial')
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(trial.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+    end
+
+    it "updates a customer with no card to a free plan" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      gratis = Stripe::Plan.create(id: 'gratis', amount: 0)
+      customer = Stripe::Customer.create(id: 'cardless', plan: 'free')
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      sub.plan = 'gratis'
+      sub.save
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan).to eq('gratis')
+
+      customer = Stripe::Customer.retrieve('cardless')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(gratis.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+    end
+
+    it "sets a card when updating a customer's subscription" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      paid = Stripe::Plan.create(id: 'paid', amount: 499)
+      customer = Stripe::Customer.create(id: 'test_customer_sub', plan: 'free')
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      sub.plan = 'paid'
+      sub.card = 'tk'
+      sub.save
+
+      customer = Stripe::Customer.retrieve('test_customer_sub')
+
+      expect(customer.cards.count).to eq(1)
+      expect(customer.cards.data.length).to eq(1)
+      expect(customer.default_card).to_not be_nil
+      expect(customer.default_card).to eq customer.cards.data.first.id
+    end
   end
 
-  it "subscribes a customer with no card to a free plan" do
-    plan = Stripe::Plan.create(id: 'free_tier', amount: 0)
-    customer = Stripe::Customer.create(id: 'cardless')
-    sub = customer.update_subscription({ :plan => 'free_tier' })
+  context "cancelling a subscription" do
 
-    expect(sub.object).to eq('subscription')
-    expect(sub.plan.id).to eq('free_tier')
-    expect(sub.plan.to_hash).to eq(plan.to_hash)
+    it "cancels a stripe customer's subscription" do
+      truth = Stripe::Plan.create(id: 'the truth')
+      customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk', plan: "the truth")
 
-    customer = Stripe::Customer.retrieve('cardless')
-    expect(customer.subscription).to_not be_nil
-    expect(customer.subscription.id).to eq(sub.id)
-    expect(customer.subscription.plan.id).to eq('free_tier')
-    expect(customer.subscription.customer).to eq(customer.id)
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      result = sub.delete()
+
+      expect(result.status).to eq('canceled')
+      expect(result.cancel_at_period_end).to be_false
+      expect(result.id).to eq(sub.id)
+
+      customer = Stripe::Customer.retrieve('test_customer_sub')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.status).to eq('canceled')
+      expect(customer.subscriptions.data.first.cancel_at_period_end).to be_false
+      expect(customer.subscriptions.data.first.ended_at).to_not be_nil
+      expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
+    end
+
+    it "cancels a stripe customer's subscription at period end" do
+      truth = Stripe::Plan.create(id: 'the truth')
+      customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk', plan: "the truth")
+
+      sub = customer.subscriptions.retrieve(customer.subscriptions.data.first.id)
+      result = sub.delete(at_period_end: true)
+
+      expect(result.status).to eq('active')
+      expect(result.cancel_at_period_end).to be_true
+      expect(result.id).to eq(sub.id)
+
+      customer = Stripe::Customer.retrieve('test_customer_sub')
+      expect(customer.subscriptions.data).to_not be_empty
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions.data.first.status).to eq('active')
+      expect(customer.subscriptions.data.first.cancel_at_period_end).to be_true
+      expect(customer.subscriptions.data.first.ended_at).to be_nil
+      expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
+    end
   end
 
-  it "subscribes a customer with no card to a plan with a free trial" do
-    plan = Stripe::Plan.create(id: 'trial', amount: 999, trial_period_days: 14)
-    customer = Stripe::Customer.create(id: 'cardless')
-    sub = customer.update_subscription({ :plan => 'trial' })
+  context "retrieve multiple subscriptions" do
 
-    expect(sub.object).to eq('subscription')
-    expect(sub.plan.id).to eq('trial')
-    expect(sub.plan.to_hash).to eq(plan.to_hash)
+    it "retrieves a list of multiple subscriptions" do
+      free = Stripe::Plan.create(id: 'free', amount: 0)
+      paid = Stripe::Plan.create(id: 'paid', amount: 499)
+      customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk', plan: "free")
+      customer.subscriptions.create({ :plan => 'paid' })
 
-    customer = Stripe::Customer.retrieve('cardless')
-    expect(customer.subscription).to_not be_nil
-    expect(customer.subscription.id).to eq(sub.id)
-    expect(customer.subscription.plan.id).to eq('trial')
-    expect(customer.subscription.customer).to eq(customer.id)
-  end
+      customer = Stripe::Customer.retrieve('test_customer_sub')
 
-  it "cancels a stripe customer's subscription" do
-    Stripe::Plan.create(id: 'the truth')
-    customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk')
-    sub = customer.update_subscription({ :plan => 'the truth' })
+      list = customer.subscriptions
 
-    result = customer.cancel_subscription
-    expect(result.status).to eq('canceled')
-    expect(result.cancel_at_period_end).to be_false
-    expect(result.id).to eq(sub.id)
+      expect(list.object).to eq("list")
+      expect(list.count).to eq(2)
+      expect(list.data.length).to eq(2)
 
-    customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.subscription).to_not be_nil
-    expect(customer.subscription.id).to eq(result.id)
-  end
+      expect(list.data.first.object).to eq("subscription")
+      expect(list.data.first.plan.to_hash).to eq(free.to_hash)
 
-  it "cancels a stripe customer's subscription at period end" do
-    Stripe::Plan.create(id: 'the truth')
-    customer = Stripe::Customer.create(id: 'test_customer_sub', card: 'tk')
-    sub = customer.update_subscription({ :plan => 'the truth' })
-
-    result = customer.cancel_subscription(at_period_end: true)
-    expect(result.status).to eq('active')
-    expect(result.cancel_at_period_end).to be_true
-    expect(result.id).to eq(sub.id)
-
-    customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.subscription).to_not be_nil
-    expect(customer.subscription.id).to eq(result.id)
-  end
-
-  it "cannot update to a plan that does not exist" do
-    customer = Stripe::Customer.create(id: 'test_customer_sub')
-    expect {
-      customer.update_subscription(plan: 'imagination')
-    }.to raise_error Stripe::InvalidRequestError
-  end
-
-  it "cannot cancel a plan that does not exist" do
-    customer = Stripe::Customer.create(id: 'test_customer_sub')
-    expect {
-      customer.cancel_subscription(plan: 'imagination')
-    }.to raise_error Stripe::InvalidRequestError
-  end
-
-  it "sets a card when updating a customer's subscription" do
-    plan = Stripe::Plan.create(id: 'small')
-    customer = Stripe::Customer.create(id: 'test_customer_sub')
-    customer.update_subscription(card: 'tk', :plan => 'small')
-
-    customer = Stripe::Customer.retrieve('test_customer_sub')
-
-    expect(customer.cards.count).to eq(1)
-    expect(customer.cards.data.length).to eq(1)
-    expect(customer.default_card).to_not be_nil
-    expect(customer.default_card).to eq customer.cards.data.first.id
+      expect(list.data.last.object).to eq("subscription")
+      expect(list.data.last.plan.to_hash).to eq(paid.to_hash)
+    end
   end
 
 end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -10,6 +10,7 @@ def require_stripe_examples
   require 'shared_stripe_examples/invoice_item_examples'
   require 'shared_stripe_examples/plan_examples'
   require 'shared_stripe_examples/recipient_examples'
+  require 'shared_stripe_examples/subscription_examples'
   require 'shared_stripe_examples/webhook_event_examples'
 end
 
@@ -24,5 +25,6 @@ def it_behaves_like_stripe(&block)
   it_behaves_like 'Plan API', &block
   it_behaves_like 'Recipient API', &block
   it_behaves_like 'Stripe Error Mocking', &block
+  it_behaves_like 'Customer Subscriptions', &block
   it_behaves_like 'Webhook Events API', &block
 end

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>= 1.8.4'
+  gem.add_dependency 'stripe', '>= 1.10.1'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
This implementation of Stripe's new multiple subscriptions features works for me.

Note that I had to upgrade the required stripe gem version to 1.10.1 because before that there wasn't a `Subscription` object in the stripe gem. Also note that I had to take out the old `update_subscription` and `cancel_subscription` methods on the `Customer` object. Pushing this out's going to break the gem for people who haven't upgraded to the latest version of the Stripe API, which is unfortunate.
