### PR TITLE
Safety on subscriptions

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -47,7 +47,7 @@ module StripeMock
 
         subscription_list = Data.mock_subscriptions_array url: "/v1/customers/#{customer[:id]}/subscriptions", count: customer[:subscriptions][:data].length
         
-        subscriptions = customer.is_a?(Hash) ? customer[:subscriptions][:data] : customer.subscriptions 
+        subscriptions = customer.is_a?(Hash) ? customer[:subscriptions][:data] : customer.subscriptions
 
         subscriptions.each do |subscription|
           subscription_list[:data] << subscription

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -319,6 +319,12 @@ shared_examples 'Customer Subscriptions' do
     expect(customer.subscriptions.data.first.status).to eq('trialing')
   end
 
+  it "should not throw error when returning no subscriptions" do
+    customer = Stripe::Customer.create(id: 'test_customer_sub')
+
+    expect(customer.subscriptions.all).to_not raise_error(NoMethodError)
+  end
+
   context "retrieve multiple subscriptions" do
 
     it "retrieves a list of multiple subscriptions" do


### PR DESCRIPTION
I was having some issues with my tests where I would get the following error:

```
Internal Server Error undefined method `subscriptions' for #<Hash:0x007fd67a591e58> 
```

This is a quick fix to get around that. Thought i'd throw it back to the master.

Thanks,

Matt
