### PR TITLE
Fixed my error on customer.subscriptions.all

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -20,6 +20,12 @@ module StripeMock
           url: "/v1/customers/#{cus_id}/cards",
           data: cards
         },
+        subscriptions: {
+          object: "list",
+          count: 0,
+          url: "/v1/customers/#{cus_id}/subscriptions",
+          data: []
+        },
         default_card: nil
       }.merge(params)
     end
@@ -257,15 +263,6 @@ module StripeMock
         :object => 'list',
         :url => '/v1/invoices?customer=test_customer'
       }
-    end
-
-    def self.mock_subscriptions_array(params={})
-      {
-        :data => [],
-        :count => 0,
-        :object => "list",
-        :url => '/v1/customers/test_customer/subscriptions',
-      }.merge(params)
     end
 
     def self.mock_plan(params={})

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -13,12 +13,12 @@ module StripeMock
       def new_customer(route, method_url, params, headers)
         params[:id] ||= new_id('cus')
         cards = []
+
         if params[:card]
           cards << get_card_by_token(params.delete(:card))
           params[:default_card] = cards.first[:id]
         end
 
-        params[:subscriptions] = Data.mock_subscriptions_array(url: "/v1/customers/#{params[:id]}/subscriptions")
         customers[ params[:id] ] = Data.mock_customer(cards, params)
 
         if params[:plan]

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -18,7 +18,6 @@ module StripeMock
 
         subscription = Data.mock_subscription params
 
-        cus[:subscriptions] = Data.mock_subscriptions_array(url: "/v1/customers/#{cus[:id]}/subscriptions") unless cus[:subscriptions]
         cus[:subscriptions][:count] = (cus[:subscriptions][:count] ? cus[:subscriptions][:count]+1 : 1 )
         cus[:subscriptions][:data] << subscription
         subscription

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -45,11 +45,7 @@ module StripeMock
         customer = customers[$1]
         assert_existance :customer, $1, customer
 
-        subscription_list = Data.mock_subscriptions_array url: "/v1/customers/#{customer[:id]}/subscriptions", count: customer[:subscriptions][:data].length
-        customer.subscriptions.each do |subscription|
-          subscription_list[:data] << subscription
-        end
-        subscription_list
+        customer[:subscriptions]
       end
 
       def update_subscription(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -329,7 +329,7 @@ shared_examples 'Customer Subscriptions' do
 
       customer = Stripe::Customer.retrieve('test_customer_sub')
 
-      list = customer.subscriptions
+      list = customer.subscriptions.all
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(2)
@@ -340,6 +340,17 @@ shared_examples 'Customer Subscriptions' do
 
       expect(list.data.last.object).to eq("subscription")
       expect(list.data.last.plan.to_hash).to eq(paid.to_hash)
+    end
+
+    it "retrieves an empty list if there's no subscriptions" do
+      Stripe::Customer.create(id: 'no_subs')
+      customer = Stripe::Customer.retrieve('no_subs')
+
+      list = customer.subscriptions.all
+
+      expect(list.object).to eq("list")
+      expect(list.count).to eq(0)
+      expect(list.data.length).to eq(0)
     end
   end
 


### PR DESCRIPTION
Because I was calling `customer.subscriptions` instead of `customer.subscriptions.all` in my test, the `retrieve_subscriptions` method in the subscription handler was never properly tested - which is a shame, because it was a bit of a mess.

This pull request fixes that mess and resolves the issues @mattvv found in issue #75.
