### PR TITLE
Supports trial_end param in customer create, subscription create / update

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -29,7 +29,11 @@ module StripeMock
             raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
           end
 
-          add_subscription_to_customer(plan, customers[params[:id]] )
+          subscription = Data.mock_subscription({ id: new_id('su') })
+          subscription.merge!(custom_subscription_params(plan, customers[ params[:id] ], params))
+          add_subscription_to_customer(customers[ params[:id] ], subscription)
+        elsif params[:trial_end]
+          raise Stripe::InvalidRequestError.new('Received unknown parameter: trial_end', nil, 400)
         end
 
         customers[ params[:id] ]

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -6,21 +6,26 @@ module StripeMock
         customer[:subscriptions][:data].find{|sub| sub[:id] == sub_id }
       end
 
-      def add_subscription_to_customer(plan, cus, start_time = nil)
-        start_time ||= Time.now.utc.to_i
-        params = { id: new_id('su'), plan: plan, customer: cus[:id], current_period_start: start_time, current_period_end: get_ending_time(start_time, plan) }
+      def custom_subscription_params(plan, cus, options = {})
+        verify_trial_end(options[:trial_end]) if options[:trial_end]
 
-        if plan[:trial_period_days].nil?
-          params.merge!({status: 'active', trial_start: nil, trial_end: nil})
+        start_time = options[:current_period_start] || Time.now.utc.to_i
+        params = { plan: plan, customer: cus[:id], current_period_start: start_time }
+
+        if (plan[:trial_period_days].nil? && options[:trial_end].nil?) || options[:trial_end] == "now"
+          end_time = get_ending_time(start_time, plan)
+          params.merge!({status: 'active', current_period_end: end_time, trial_start: nil, trial_end: nil})
         else
-          params.merge!({status: 'trialing', trial_start: Time.now.utc.to_i, trial_end: (Time.now.utc.to_i + plan[:trial_period_days]*86400) })
+          end_time = options[:trial_end] || (Time.now.utc.to_i + plan[:trial_period_days]*86400)
+          params.merge!({status: 'trialing', current_period_end: end_time, trial_start: start_time, trial_end: end_time})
         end
 
-        subscription = Data.mock_subscription params
+        params
+      end
 
+      def add_subscription_to_customer(cus, sub)
         cus[:subscriptions][:count] = (cus[:subscriptions][:count] ? cus[:subscriptions][:count]+1 : 1 )
-        cus[:subscriptions][:data] << subscription
-        subscription
+        cus[:subscriptions][:data] << sub
       end
 
       # intervals variable is set to 1 when calculating current_period_end from current_period_start & plan
@@ -35,6 +40,18 @@ module StripeMock
             (Time.at(start_time).to_datetime >> (12 * intervals)).to_time.to_i # max period is 1 year
           else
             start_time
+        end
+      end
+
+      def verify_trial_end(trial_end)
+        if trial_end != "now"
+          if !trial_end.is_a? Integer
+            raise Stripe::InvalidRequestError.new('Invalid timestamp: must be an integer', nil, 400)
+          elsif trial_end < Time.now.utc.to_i
+            raise Stripe::InvalidRequestError.new('Invalid timestamp: must be an integer Unix timestamp in the future', nil, 400)
+          elsif trial_end > Time.now.utc.to_i + 31557600*5 # five years
+            raise Stripe::InvalidRequestError.new('Invalid timestamp: can be no more than five years in the future', nil, 400)
+          end
         end
       end
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -47,6 +47,75 @@ shared_examples 'Customer API' do
     expect(customer.subscriptions.first.customer).to eq(customer.id)
   end
 
+  context "create customer" do
+
+    it "with a trial when trial_end is set" do
+      plan = Stripe::Plan.create(id: 'no_trial', amount: 999)
+      trial_end = Time.now.utc.to_i + 3600
+      customer = Stripe::Customer.create(id: 'test_cus_trial_end', card: 'tk', plan: 'no_trial', trial_end: trial_end)
+
+      customer = Stripe::Customer.retrieve('test_cus_trial_end')
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions).to_not be_nil
+      expect(customer.subscriptions.first.plan.id).to eq('no_trial')
+      expect(customer.subscriptions.first.status).to eq('trialing')
+      expect(customer.subscriptions.first.current_period_end).to eq(trial_end)
+      expect(customer.subscriptions.first.trial_end).to eq(trial_end)
+    end
+
+    it 'overrides trial period length when trial_end is set' do
+      plan = Stripe::Plan.create(id: 'silver', amount: 999, trial_period_days: 14)
+      trial_end = Time.now.utc.to_i + 3600
+      customer = Stripe::Customer.create(id: 'test_cus_trial_end', card: 'tk', plan: 'silver', trial_end: trial_end)
+
+      customer = Stripe::Customer.retrieve('test_cus_trial_end')
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions).to_not be_nil
+      expect(customer.subscriptions.first.plan.id).to eq('silver')
+      expect(customer.subscriptions.first.current_period_end).to eq(trial_end)
+      expect(customer.subscriptions.first.trial_end).to eq(trial_end)
+    end
+
+    it "returns no trial when trial_end is set to 'now'" do
+      plan = Stripe::Plan.create(id: 'silver', amount: 999, trial_period_days: 14)
+      customer = Stripe::Customer.create(id: 'test_cus_trial_end', card: 'tk', plan: 'silver', trial_end: "now")
+
+      customer = Stripe::Customer.retrieve('test_cus_trial_end')
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions).to_not be_nil
+      expect(customer.subscriptions.first.plan.id).to eq('silver')
+      expect(customer.subscriptions.first.status).to eq('active')
+      expect(customer.subscriptions.first.trial_start).to be_nil
+      expect(customer.subscriptions.first.trial_end).to be_nil
+    end
+
+    it "returns an error if trial_end is set to a past time" do
+      plan = Stripe::Plan.create(id: 'silver', amount: 999)
+      expect {
+        Stripe::Customer.create(id: 'test_cus_trial_end', card: 'tk', plan: 'silver', trial_end: Time.now.utc.to_i - 3600)
+      }.to raise_error {|e|
+        expect(e).to be_a(Stripe::InvalidRequestError)
+        expect(e.message).to eq('Invalid timestamp: must be an integer Unix timestamp in the future')
+      }
+    end
+
+    it "returns an error if trial_end is set without a plan" do
+      expect {
+        Stripe::Customer.create(id: 'test_cus_trial_end', card: 'tk', trial_end: "now")
+      }.to raise_error {|e|
+        expect(e).to be_a(Stripe::InvalidRequestError)
+        expect(e.message).to eq('Received unknown parameter: trial_end')
+      }
+    end
+
+  end
+
   it 'cannot create a customer with a plan that does not exist' do
     expect {
       customer = Stripe::Customer.create(id: 'test_cus_no_plan', card: 'tk', :plan => 'non-existant')


### PR DESCRIPTION
This pull request provides full support for the trial_end parameter when creating a customer, creating a subscription, or updating a subscription. 

I wrote this because I have multiple payment plans in my app, each with a free trial, but didn't want customers switching from one plan to the next and getting a new free trial. I do this by setting trial_end of the new plan to trial_end of the old plan, or to "now" if the trial is completely finished.

Some notes on how trial_end works (all working exactly like the Stripe API):
- trial_end must be an integer Unix timestamp or the word 'now'. Anything else returns an invalid request error.
- trial_end cannot be in the past or more than five years in the future. If so, it returns an invalid request error.
- when creating a customer, 'trial_end' must be accompanied by 'plan'. If there's no plan, submitting trial_end results in an invalid request error.
- setting trial_end to a timestamp will create a subscription / modify an existing subscription to be in a 'trialing' status, with a trial period ending on 'trial_end'. The 'current_period_start' and 'current_period_end' will match the 'trial_start' and 'trial_end' respectively.
- setting trial_end to 'now', will create a subscription / modify an existing subscription to be in an 'active' status, without a trial period. The 'trial_end' and 'trial_start' values are nil. If the subscription was already 'active', this has no effect.

Some implementation notes:
- I split 'add_subscription_to_customer' into two methods, 'custom_subscription_params' and 'add_subscription_to_customer'. The 'custom_subscription_params' method is used both when creating and editing subscriptions, while 'add_subscription_to_customer' is used only when adding a brand new subscription to a customer
- I've separated out a 'verify_trial_end' method to takes care of the error handling for trial_end - not a timestamp, in the past, too far in the future, etc. This was done for readability, it's only called from 'custom_subscription_params'.
