### PR TITLE
Test fix for 31st of month corner case

### DIFF
--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -107,7 +107,7 @@ shared_examples 'Invoice API' do
       expect(@upcoming.total).to eq(@upcoming.lines.data[0].amount)
       expect(@upcoming.period_end).to eq(@upcoming.lines.data[0].period.start)
       expect(Time.at(@upcoming.period_start).to_datetime >> 1).to eq(Time.at(@upcoming.period_end).to_datetime) # +1 month
-      expect(Time.at(@upcoming.period_end).to_datetime >> 1).to eq(Time.at(@upcoming.lines.data[0].period.end).to_datetime) # +1 month
+      expect(Time.at(@upcoming.period_start).to_datetime >> 2).to eq(Time.at(@upcoming.lines.data[0].period.end).to_datetime) # +1 month
       expect(@upcoming.next_payment_attempt).to eq(@upcoming.period_end + 3600) # +1 hour
       expect(@upcoming.subscription).to eq(@subscription.id)
     end


### PR DESCRIPTION
On the last day of a 31-day-long month that precedes a 30-day-long month (like today, the 31st of March), `DateTime >> 1 >> 1` is not equal to `DateTime >> 2`.

In the case of `DateTime >> 1 >> 1`, March 31 becomes April 30, which then becomes May 30, but in the case of `DateTime >> 2`, March 31 becomes May 31.

In the test below, I incorrectly assumed `DateTime >> 1 >> 1` would always equal `DateTime >> 2`. This has now been fixed.
