### PR TITLE
Add missing attributes to mock charge

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -63,12 +63,18 @@ module StripeMock
           address_zip_check: nil
         },
         captured: params.has_key?(:capture) ? params.delete(:capture) : true,
+        refunds: [
+        ],
+        balance_transaction: "txn_2dyYXXP90MN26R",
         failure_message: nil,
+        failure_code: nil,
         amount_refunded: 0,
         customer: nil,
         invoice: nil,
         description: nil,
-        dispute: nil
+        dispute: nil,
+        metadata: {
+        }
       }.merge(params)
     end
 


### PR DESCRIPTION
Looking at the [Stripe API reference](https://stripe.com/docs/api#create_charge), it appears some atttributes were missing from the `mock_charge` response.
