### PR TITLE
Fix bug in array merge

### DIFF
--- a/lib/stripe_mock/util.rb
+++ b/lib/stripe_mock/util.rb
@@ -7,6 +7,7 @@ module StripeMock
 
       desh_hash.merge(source_hash) do |key, oldval, newval|
         if oldval.is_a?(Array) && newval.is_a?(Array)
+          oldval.fill(nil, oldval.length...newval.length)
           oldval.zip(newval).map {|elems|
             elems[1].nil? ? elems[0] : rmerge(elems[0], elems[1])
           }

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -26,6 +26,14 @@ describe StripeMock::Util do
     expect(result).to eq({ x: [ {a: 0}, {a: 0, b: 2}, {c: 3} ] })
   end
 
+  it "does not truncate the array when merging" do
+    dest = { x: [ {a: 1}, {b: 2} ] }
+    source = { x: [ nil, nil, {c: 3} ] }
+    result = StripeMock::Util.rmerge(dest, source)
+
+    expect(result).to eq({ x: [ {a: 1}, {b: 2}, {c: 3} ] })
+  end
+
   it "treats an array nil element as a skip op" do
     dest = { x: [ {a: 1}, {b: 2}, {c: 3} ] }
     source = { x: [ nil, nil, {c: 0} ] }


### PR DESCRIPTION
We were unable to mock charges with more than one refund because the merge was limited by the size of the array in the fixture. 

The receiver of the `zip` method limits the size of the output.
