### PR TITLE
Add handler for get /v1/customers/:id/cards

### DIFF
--- a/lib/stripe_mock/request_handlers/cards.rb
+++ b/lib/stripe_mock/request_handlers/cards.rb
@@ -3,6 +3,7 @@ module StripeMock
     module Cards
 
       def Cards.included(klass)
+        klass.add_handler 'get /v1/customers/(.*)/cards', :retrieve_cards
         klass.add_handler 'post /v1/customers/(.*)/cards', :create_card
         klass.add_handler 'get /v1/customers/(.*)/cards/(.*)', :retrieve_card
         klass.add_handler 'delete /v1/customers/(.*)/cards/(.*)', :delete_card
@@ -17,6 +18,17 @@ module StripeMock
 
         card = card_from_params(params[:card])
         add_card_to_customer(card, customer)
+      end
+
+      def retrieve_cards(route, method_url, params, headers)
+        route =~ method_url
+
+        customer = customers[$1]
+        assert_existance :customer, $1, customer
+
+        cards = customer[:cards]
+        cards[:count] = cards[:data].length
+        cards
       end
 
       def retrieve_card(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -92,4 +92,41 @@ shared_examples 'Card API' do
     end
   end
 
+  context "retrieve multiple cards" do
+
+    it "retrieves a list of multiple cards" do
+      customer = Stripe::Customer.create(id: 'test_customer_card')
+
+      card_token = StripeMock.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
+      card1 = customer.cards.create(card: card_token)
+      card_token = StripeMock.generate_card_token(last4: "1124", exp_month: 12, exp_year: 2098)
+      card2 = customer.cards.create(card: card_token)
+
+      customer = Stripe::Customer.retrieve('test_customer_card')
+
+      list = customer.cards.all
+
+      expect(list.object).to eq("list")
+      expect(list.count).to eq(2)
+      expect(list.data.length).to eq(2)
+
+      expect(list.data.first.object).to eq("card")
+      expect(list.data.first.to_hash).to eq(card1.to_hash)
+
+      expect(list.data.last.object).to eq("card")
+      expect(list.data.last.to_hash).to eq(card2.to_hash)
+    end
+
+    it "retrieves an empty list if there's no subscriptions" do
+      Stripe::Customer.create(id: 'no_cards')
+      customer = Stripe::Customer.retrieve('no_cards')
+
+      list = customer.cards.all
+
+      expect(list.object).to eq("list")
+      expect(list.count).to eq(0)
+      expect(list.data.length).to eq(0)
+    end
+  end
+
 end


### PR DESCRIPTION
This adds support for this endpoint : https://stripe.com/docs/api/ruby#list_cards

I had to add this weird count thing in the handler otherwise the card count would always be 1.
Let me know if there is a better way to achieve this, I would be more than happy to update the PR.

I used this PR https://github.com/rebelidealist/stripe-ruby-mock/pull/77 as an inspiration.
