### PR TITLE
Allow Stripe::Token to accept customer id instead of card

### DIFF
--- a/spec/shared_stripe_examples/card_token_examples.rb
+++ b/spec/shared_stripe_examples/card_token_examples.rb
@@ -85,6 +85,26 @@ shared_examples 'Card Token Mocking' do
       expect(card.exp_month).to eq(11)
       expect(card.exp_year).to eq(2019)
     end
+
+    it "generates a card token created from customer" do
+      card_token = Stripe::Token.create({
+        card: {
+          number: "1111222233334444",
+          exp_month: 11,
+          exp_year: 2019
+        }
+      })
+
+      cus = Stripe::Customer.create()
+      cus.card = card_token.id
+      cus.save
+
+      card_token = Stripe::Token.create({
+        customer: cus.id
+      })
+
+      expect(card_token.object).to eq("token")
+    end
   end
 
 end


### PR DESCRIPTION
When using [Stripe Connect's Shared Customers](https://stripe.com/docs/api#create_card_token), the [Create Token API](https://stripe.com/docs/api#create_card_token) is used to generate a token in place of a customer's card token.  Many times, including in Stripe's example for Shared Customers, you'll only need to pass in the `customer_id`.

This change makes it possible to pass in just the customer to the `create_token` method.
