### PR TITLE
Reformatted refunds array to hash /w data

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -63,8 +63,8 @@ module StripeMock
           address_zip_check: nil
         },
         captured: params.has_key?(:capture) ? params.delete(:capture) : true,
-        refunds: [
-        ],
+        refunds: {
+        },
         balance_transaction: "txn_2dyYXXP90MN26R",
         failure_message: nil,
         failure_code: nil,
@@ -81,15 +81,20 @@ module StripeMock
     def self.mock_refund(params={})
       mock_charge(params[:charge]).merge({
         refunded: true,
-        refunds: [
-          {
-            amount: params[:refund][:amount],
-            currency: "usd",
-            created: 1380208998,
-            object: "refund",
-            balance_transaction: params[:refund][:balance_transaction]
-          }
-        ],
+        refunds: {
+          object: "list",
+          total_count: 1,
+          has_more: false,
+          data: [
+            {
+              amount: params[:refund][:amount],
+              currency: "usd",
+              created: 1380208998,
+              object: "refund",
+              balance_transaction: params[:refund][:balance_transaction]
+            }
+          ]
+        },
         amount_refunded: params[:refund][:amount]
       })
     end

--- a/lib/stripe_mock/webhook_fixtures/charge.failed.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.failed.json
@@ -36,9 +36,9 @@
         "address_zip_check": null
       },
       "captured": true,
-      "refunds": [
+      "refunds": {
 
-      ],
+      },
       "balance_transaction": "txn_00000000000000",
       "failure_message": null,
       "failure_code": null,

--- a/lib/stripe_mock/webhook_fixtures/charge.refunded.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.refunded.json
@@ -36,15 +36,20 @@
         "address_zip_check": null
       },
       "captured": true,
-      "refunds": [
-        {
-          "amount": 1000,
-          "currency": "usd",
-          "created": 1381080103,
-          "object": "refund",
-          "balance_transaction": "txn_2hkjgg43ucu7K1"
-        }
-      ],
+      "refunds": {
+        "object": "list",
+        "total_count": 1,
+        "has_more": false,
+        "data": [
+          {
+            "amount": 1000,
+            "currency": "usd",
+            "created": 1381080103,
+            "object": "refund",
+            "balance_transaction": "txn_2hkjgg43ucu7K1"
+          }
+        ]
+      },
       "balance_transaction": "txn_00000000000000",
       "failure_message": null,
       "failure_code": null,

--- a/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
@@ -36,9 +36,9 @@
         "address_zip_check": null
       },
       "captured": true,
-      "refunds": [
+      "refunds": {
 
-      ],
+      },
       "balance_transaction": "txn_00000000000000",
       "failure_message": null,
       "failure_code": null,

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 shared_examples 'Refund API' do
-  
+
   it "refunds a stripe charge item" do
     charge = Stripe::Charge.create(
       amount: 999,
@@ -13,7 +13,7 @@ shared_examples 'Refund API' do
     charge = charge.refund(amount: 999)
 
     expect(charge.refunded).to eq(true)
-    expect(charge.refunds.first.amount).to eq(999)
+    expect(charge.refunds.data.first.amount).to eq(999)
     expect(charge.amount_refunded).to eq(999)
   end
 
@@ -39,6 +39,6 @@ shared_examples 'Refund API' do
     )
     refund = charge.refund
 
-    expect(charge.balance_transaction).not_to eq(refund.refunds.first.balance_transaction)
+    expect(charge.balance_transaction).not_to eq(refund.refunds.data.first.balance_transaction)
   end
 end


### PR DESCRIPTION
Matches API changes made on [2014-06-17](https://stripe.com/docs/upgrades#2014-06-17):

> Change refunds property on charge responses from an array to a sublist object, which contains the total_count, has_more, url, and data parameters.
