### PR TITLE
New subscriptions show up before old ones

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -27,7 +27,7 @@ module StripeMock
 
       def add_subscription_to_customer(cus, sub)
         cus[:subscriptions][:count] = (cus[:subscriptions][:count] || 0) + 1
-        cus[:subscriptions][:data] << sub
+        cus[:subscriptions][:data].unshift sub
       end
 
       # `intervals` is set to 1 when calculating current_period_end from current_period_start & plan

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -58,12 +58,12 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.count).to eq(2)
       expect(customer.subscriptions.data.length).to eq(2)
 
-      expect(customer.subscriptions.data.first.plan.to_hash).to eq(gold.to_hash)
-      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
-
-      expect(customer.subscriptions.data.last.id).to eq(sub.id)
-      expect(customer.subscriptions.data.last.plan.to_hash).to eq(silver.to_hash)
+      expect(customer.subscriptions.data.last.plan.to_hash).to eq(gold.to_hash)
       expect(customer.subscriptions.data.last.customer).to eq(customer.id)
+
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.plan.to_hash).to eq(silver.to_hash)
+      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
     end
 
     it "subscribes a cardless customer when specifing a card token" do
@@ -513,11 +513,11 @@ shared_examples 'Customer Subscriptions' do
       expect(list.count).to eq(2)
       expect(list.data.length).to eq(2)
 
-      expect(list.data.first.object).to eq("subscription")
-      expect(list.data.first.plan.to_hash).to eq(free.to_hash)
-
       expect(list.data.last.object).to eq("subscription")
-      expect(list.data.last.plan.to_hash).to eq(paid.to_hash)
+      expect(list.data.last.plan.to_hash).to eq(free.to_hash)
+
+      expect(list.data.first.object).to eq("subscription")
+      expect(list.data.first.plan.to_hash).to eq(paid.to_hash)
     end
 
     it "retrieves an empty list if there's no subscriptions" do


### PR DESCRIPTION
In the latest stripe gem (1.14.0), it appears that creating a new subscription pushes it to the beginning of the subscriptions array rather than appending it at the end.

Example:

``` ruby
2.1.1 :183 > customer = Stripe::Customer.retrieve('cus_4QAbut8qjQJxkA')
 => #<Stripe::Customer:0x81ae69ac id=cus_4QAbut8qjQJxkA> JSON: {
  "id": "cus_4QAbut8qjQJxkA",
  "object": "customer",
  "created": 1405624183,
  "livemode": false,
  "description": "foobar",
  "email": null,
  "delinquent": false,
  "metadata": {},
  "subscriptions": {"object":"list","total_count":0,"has_more":false,"url":"/v1/customers/cus_4QAbut8qjQJxkA/subscriptions","data":[]},
  "discount": null,
  "account_balance": 0,
  "currency": "usd",
  "cards": {"object":"list","total_count":0,"has_more":false,"url":"/v1/customers/cus_4QAbut8qjQJxkA/cards","data":[]},
  "default_card": null
}
2.1.1 :184 > first = customer.subscriptions.create(plan: 'standard_monthly')
 => #<Stripe::Subscription:0x81af2f40 id=sub_4QI9h9Sio65qKO> JSON: {
  "id": "sub_4QI9h9Sio65qKO",
  "plan": {"id":"standard_monthly","interval":"month","name":"Standard Monthly","created":1404788864,"amount":2000,"currency":"usd","object":"plan","livemode":false,"interval_count":1,"trial_period_days":14,"metadata":{},"statement_description":null},
  "object": "subscription",
  "start": 1405652259,
  "status": "trialing",
  "customer": "cus_4QAbut8qjQJxkA",
  "cancel_at_period_end": false,
  "current_period_start": 1405652259,
  "current_period_end": 1406861859,
  "ended_at": null,
  "trial_start": 1405652259,
  "trial_end": 1406861859,
  "canceled_at": null,
  "quantity": 1,
  "application_fee_percent": null,
  "discount": null,
  "metadata": {}
}
2.1.1 :185 > second = customer.subscriptions.create(plan: 'standard_monthly')
 => #<Stripe::Subscription:0x82789808 id=sub_4QI9isrhk6lqnu> JSON: {
  "id": "sub_4QI9isrhk6lqnu",
  "plan": {"id":"standard_monthly","interval":"month","name":"Standard Monthly","created":1404788864,"amount":2000,"currency":"usd","object":"plan","livemode":false,"interval_count":1,"trial_period_days":14,"metadata":{},"statement_description":null},
  "object": "subscription",
  "start": 1405652262,
  "status": "trialing",
  "customer": "cus_4QAbut8qjQJxkA",
  "cancel_at_period_end": false,
  "current_period_start": 1405652262,
  "current_period_end": 1406861862,
  "ended_at": null,
  "trial_start": 1405652262,
  "trial_end": 1406861862,
  "canceled_at": null,
  "quantity": 1,
  "application_fee_percent": null,
  "discount": null,
  "metadata": {}
}
2.1.1 :186 > third = customer.subscriptions.create(plan: 'standard_monthly')
 => #<Stripe::Subscription:0x827a44b4 id=sub_4QI9BfyRCIQdZw> JSON: {
  "id": "sub_4QI9BfyRCIQdZw",
  "plan": {"id":"standard_monthly","interval":"month","name":"Standard Monthly","created":1404788864,"amount":2000,"currency":"usd","object":"plan","livemode":false,"interval_count":1,"trial_period_days":14,"metadata":{},"statement_description":null},
  "object": "subscription",
  "start": 1405652266,
  "status": "trialing",
  "customer": "cus_4QAbut8qjQJxkA",
  "cancel_at_period_end": false,
  "current_period_start": 1405652266,
  "current_period_end": 1406861866,
  "ended_at": null,
  "trial_start": 1405652266,
  "trial_end": 1406861866,
  "canceled_at": null,
  "quantity": 1,
  "application_fee_percent": null,
  "discount": null,
  "metadata": {}
}
2.1.1 :187 > customer = Stripe::Customer.retrieve('cus_4QAbut8qjQJxkA')
 => #<Stripe::Customer:0x827b0778 id=cus_4QAbut8qjQJxkA> JSON: {
  "id": "cus_4QAbut8qjQJxkA",
  "object": "customer",
  "created": 1405624183,
  "livemode": false,
  "description": "foobar",
  "email": null,
  "delinquent": false,
  "metadata": {},
  "subscriptions": {"object":"list","total_count":3,"has_more":false,"url":"/v1/customers/cus_4QAbut8qjQJxkA/subscriptions","data":[{"id":"sub_4QI9BfyRCIQdZw","plan":{"id":"standard_monthly","interval":"month","name":"Standard Monthly","created":1404788864,"amount":2000,"currency":"usd","object":"plan","livemode":false,"interval_count":1,"trial_period_days":14,"metadata":{},"statement_description":null},"object":"subscription","start":1405652266,"status":"trialing","customer":"cus_4QAbut8qjQJxkA","cancel_at_period_end":false,"current_period_start":1405652266,"current_period_end":1406861866,"ended_at":null,"trial_start":1405652266,"trial_end":1406861866,"canceled_at":null,"quantity":1,"application_fee_percent":null,"discount":null,"metadata":{}},{"id":"sub_4QI9isrhk6lqnu","plan":{"id":"standard_monthly","interval":"month","name":"Standard Monthly","created":1404788864,"amount":2000,"currency":"usd","object":"plan","livemode":false,"interval_count":1,"trial_period_days":14,"metadata":{},"statement_description":null},"object":"subscription","start":1405652262,"status":"trialing","customer":"cus_4QAbut8qjQJxkA","cancel_at_period_end":false,"current_period_start":1405652262,"current_period_end":1406861862,"ended_at":null,"trial_start":1405652262,"trial_end":1406861862,"canceled_at":null,"quantity":1,"application_fee_percent":null,"discount":null,"metadata":{}},{"id":"sub_4QI9h9Sio65qKO","plan":{"id":"standard_monthly","interval":"month","name":"Standard Monthly","created":1404788864,"amount":2000,"currency":"usd","object":"plan","livemode":false,"interval_count":1,"trial_period_days":14,"metadata":{},"statement_description":null},"object":"subscription","start":1405652259,"status":"trialing","customer":"cus_4QAbut8qjQJxkA","cancel_at_period_end":false,"current_period_start":1405652259,"current_period_end":1406861859,"ended_at":null,"trial_start":1405652259,"trial_end":1406861859,"canceled_at":null,"quantity":1,"application_fee_percent":null,"discount":null,"metadata":{}}]},
  "discount": null,
  "account_balance": 0,
  "currency": "usd",
  "cards": {"object":"list","total_count":0,"has_more":false,"url":"/v1/customers/cus_4QAbut8qjQJxkA/cards","data":[]},
  "default_card": null
}
2.1.1 :188 > customer_ids = customer.subscriptions.data.map(&:id)
 => ["sub_4QI9BfyRCIQdZw", "sub_4QI9isrhk6lqnu", "sub_4QI9h9Sio65qKO"]
2.1.1 :189 > expected_ids = [third, second, first].map(&:id)
 => ["sub_4QI9BfyRCIQdZw", "sub_4QI9isrhk6lqnu", "sub_4QI9h9Sio65qKO"]
2.1.1 :190 > customer_ids == expected_ids
 => true
```
