### PR TITLE
add_card helper should only remove default_card on Customer update

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -49,7 +49,7 @@ module StripeMock
 
         if params[:card]
           new_card = get_card_by_token(params.delete(:card))
-          add_card_to_customer(new_card, cus)
+          add_card_to_customer(new_card, cus, true)
           cus[:default_card] = new_card[:id]
         end
 

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -6,12 +6,12 @@ module StripeMock
         customer[:cards][:data].find{|cc| cc[:id] == token }
       end
 
-      def add_card_to_customer(card, cus)
+      def add_card_to_customer(card, cus, replace_default = false)
         card[:customer] = cus[:id]
 
         if cus[:cards][:count] == 0
           cus[:cards][:count] += 1
-        else
+        elsif cus[:cards][:count] > 0 && replace_default
           cus[:cards][:data].delete_if {|card| card[:id] == cus[:default_card]}
         end
 

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -43,6 +43,16 @@ shared_examples 'Card API' do
     expect(card.exp_year).to eq(3031)
   end
 
+  it 'create adds cards' do
+    card_token1 = StripeMock.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
+    card_token2 = StripeMock.generate_card_token(last4: "9923", exp_month: 11, exp_year: 2099)
+    customer = Stripe::Customer.create(id: 'test_customer_sub', card: card_token1)
+    card = customer.cards.create(card: card_token2)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.cards.all.count).to eq(2)
+  end
+
   it 'create does not change the customers default card' do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     card_token = StripeMock.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)


### PR DESCRIPTION
When the Stripe Customer record is [updated](https://stripe.com/docs/api#update_customer) with a card, the
default_card is reset to the newly specified card. Other calls to card
creation do not modify the default_card nor delete old cards associated
with the customer.
