### PR TITLE
Fixes #149. When a stripe charge is created with both a customer and car...

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -14,14 +14,17 @@ module StripeMock
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
 
-        # if a customer is provided, the card parameter is assumed to be the actual
-        # card id, not a token.
-        unless params[:customer]
-          if params[:card] && params[:card].is_a?(String)
+        if params[:card] && params[:card].is_a?(String)
+          # if a customer is provided, the card parameter is assumed to be the actual
+          # card id, not a token. in this case we'll find the card in the customer
+          # object and return that.
+          if params[:customer]
+            params[:card] = get_card(customers[params[:customer]], params[:card])
+          else
             params[:card] = get_card_by_token(params[:card])
-          elsif params[:card] && params[:card][:id]
-            raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:card]}", 'card', 400)
           end
+        elsif params[:card] && params[:card][:id]
+          raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:card]}", 'card', 400)
         end
 
         charges[id] = Data.mock_charge(params.merge :id => id, :balance_transaction => new_balance_transaction('txn'))

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -30,12 +30,13 @@ shared_examples 'Charge API' do
   it "creates a stripe charge item with a customer and card id" do
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: stripe_helper.generate_card_token,
+      card: stripe_helper.generate_card_token(number: '4012888888881881'),
       description: "a description"
     })
 
     expect(customer.cards.data.length).to eq(1)
     expect(customer.cards.data[0].id).not_to be_nil
+    expect(customer.cards.data[0].last4).to eq('1881')
 
     card   = customer.cards.data[0]
     charge = Stripe::Charge.create(
@@ -50,6 +51,7 @@ shared_examples 'Charge API' do
     expect(charge.amount).to eq(999)
     expect(charge.description).to eq('a charge with a specific card')
     expect(charge.captured).to eq(true)
+    expect(charge.card.last4).to eq('1881')
   end
 
 


### PR DESCRIPTION
...d parameters the card is assumed to be a card id (not a token). added test to ensure proper functionality
