### PR TITLE
Update trial_will_end fixture

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.trial_will_end.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.trial_will_end.json
@@ -4,33 +4,45 @@
   "id": "evt_00000000000000",
   "type": "customer.subscription.trial_will_end",
   "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2014-11-05",
   "data": {
     "object": {
-      "id": "su_00000000000000",
+      "id": "sub_00000000000000",
       "plan": {
         "interval": "month",
         "name": "Member's Club",
-        "amount": 100,
-        "currency": "usd",
-        "id": "fkx0AFo_00000000000000",
+        "created": 1422042571,
+        "amount": 2499,
+        "currency": "eur",
+        "id": "kx0AFo_00000000000000",
         "object": "plan",
         "livemode": false,
         "interval_count": 1,
-        "trial_period_days": null
+        "trial_period_days": 14,
+        "metadata": {
+        },
+        "statement_descriptor": "Member's Club",
+        "statement_description": "Member's Club"
       },
       "object": "subscription",
-      "start": 1381080623,
+      "start": 1422114329,
       "status": "trialing",
       "customer": "cus_00000000000000",
       "cancel_at_period_end": false,
-      "current_period_start": 1381080623,
-      "current_period_end": 1383759023,
+      "current_period_start": 1422114329,
+      "current_period_end": 1423323929,
       "ended_at": null,
-      "trial_start": 1381021530,
-      "trial_end": 1381280730,
+      "trial_start": 1422072095,
+      "trial_end": 1422331295,
       "canceled_at": null,
       "quantity": 1,
-      "application_fee_percent": null
+      "application_fee_percent": null,
+      "discount": null,
+      "tax_percent": null,
+      "metadata": {
+      }
     }
   }
 }


### PR DESCRIPTION
Hi,
trial_will_end webhook fixture doesn't works with new default Stripe API version. I've updated to the new version.
