### PR TITLE
Allow the tax_percent to be set when the subscription is created.

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -11,7 +11,7 @@ module StripeMock
 
         start_time = options[:current_period_start] || Time.now.utc.to_i
         params = { plan: plan, customer: cus[:id], current_period_start: start_time }
-        params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata/}
+        params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata|tax_percent/}
         # TODO: Implement coupon logic
 
         if (plan[:trial_period_days].nil? && options[:trial_end].nil?) || options[:trial_end] == "now"

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -34,7 +34,7 @@ shared_examples 'Customer Subscriptions' do
 
     end
 
-    it "correctly sets quantity and application_fee_percent" do
+    it "correctly sets quantity, application_fee_percent and tax_percent" do
       Stripe::Plan.create(
         :amount => 2500,
         :interval => 'month',
@@ -46,9 +46,10 @@ shared_examples 'Customer Subscriptions' do
       customer = Stripe::Customer.create(id: 'test_customer_sub', card: gen_card_tk)
 
       subscription = customer.subscriptions.create({
-        :plan => "silver", quantity: 2, application_fee_percent: 10})
+        :plan => "silver", quantity: 2, application_fee_percent: 10, tax_percent: 20})
       expect(subscription.quantity).to eq(2)
       expect(subscription.application_fee_percent).to eq(10)
+      expect(subscription.tax_percent).to eq(20)
     end
 
     it "adds additional subscription to customer with existing subscription" do


### PR DESCRIPTION
Although the tax_percent has a default value, the custom_subscription_params method wasn't allowing it to be set when creating a subscription with a non-default tax_rate.
