### PR TITLE
Add Accounts

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -41,6 +41,7 @@ require 'stripe_mock/request_handlers/helpers/token_helpers.rb'
 
 require 'stripe_mock/request_handlers/validators/param_validators.rb'
 
+require 'stripe_mock/request_handlers/accounts.rb'
 require 'stripe_mock/request_handlers/charges.rb'
 require 'stripe_mock/request_handlers/cards.rb'
 require 'stripe_mock/request_handlers/sources.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -85,8 +85,8 @@ module StripeMock
           avs_failure: false
         },
         keys: {
-          secret: nil,
-          publishable: nil
+          secret: 'SECRETKEY',
+          publishable: 'PUBLISHABLEKEY'
         }
       }.merge(params)
     end

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -3,7 +3,7 @@ module StripeMock
 
     def self.mock_account(params = {})
       id = params[:id] || 'acct_103ED82ePvKYlo2C'
-      {
+      StripeMock::Util.rmerge({
         id: id,
         email: "bob@example.com",
         statement_descriptor: nil,
@@ -88,13 +88,13 @@ module StripeMock
           secret: 'SECRETKEY',
           publishable: 'PUBLISHABLEKEY'
         }
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
       sources.each {|source| source[:customer] = cus_id}
-      {
+      StripeMock::Util.rmerge({
         email: 'stripe_mock@example.com',
         description: 'an auto-generated stripe customer data mock',
         object: "customer",
@@ -117,12 +117,12 @@ module StripeMock
           data: []
         },
         default_source: nil
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_charge(params={})
       charge_id = params[:id] || "ch_1fD6uiR9FAA2zc"
-      {
+      StripeMock::Util.rmerge({
         id: charge_id,
         object: "charge",
         created: 1366194027,
@@ -174,11 +174,11 @@ module StripeMock
         dispute: nil,
         metadata: {
         }
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_refund(params={})
-      {
+      StripeMock::Util.rmerge({
         id: "re_4fWhgUh5si7InF",
         amount: 1,
         currency: "usd",
@@ -187,7 +187,7 @@ module StripeMock
         balance_transaction: "txn_4fWh2RKvgxcXqV",
         metadata: {},
         charge: "ch_4fWhYjzQ23UFWT"
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_charge_array
@@ -225,7 +225,7 @@ module StripeMock
     end
 
     def self.mock_bank_account(params={})
-      {
+      StripeMock::Util.rmerge({
         object: "bank_account",
         bank_name: "STRIPEMOCK TEST BANK",
         last4: "6789",
@@ -233,11 +233,11 @@ module StripeMock
         currency: "usd",
         validated: false,
         fingerprint: "aBcFinGerPrINt123"
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_coupon(params={})
-      {
+      StripeMock::Util.rmerge({
         :duration => 'repeating',
         :duration_in_months => 3,
         :percent_off => 25,
@@ -250,7 +250,7 @@ module StripeMock
         :times_redeemed => 0,
         :valid => true,
         :metadata => {},
-      }.merge(params)
+      }, params)
     end
 
     #FIXME nested overrides would be better than hardcoding plan_id
@@ -283,7 +283,7 @@ module StripeMock
     def self.mock_invoice(lines, params={})
       in_id = params[:id] || "test_in_default"
       lines << Data.mock_line_item() if lines.empty?
-      {
+      StripeMock::Util.rmerge({
         id: 'in_test_invoice',
         date: 1349738950,
         period_end: 1349738950,
@@ -312,11 +312,11 @@ module StripeMock
         charge: nil,
         discount: nil,
         subscription: nil
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_line_item(params = {})
-      {
+      StripeMock::Util.rmerge({
         id: "ii_test",
         object: "line_item",
         type: "invoiceitem",
@@ -332,11 +332,11 @@ module StripeMock
         plan: nil,
         description: "Test invoice item",
         metadata: {}
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_invoice_item(params = {})
-      {
+      StripeMock::Util.rmerge({
         id: "test_ii",
         object: "invoiceitem",
         date: 1349738920,
@@ -349,7 +349,7 @@ module StripeMock
         metadata: {},
         invoice: nil,
         subscription: nil
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_paid_invoice
@@ -373,7 +373,7 @@ module StripeMock
     end
 
     def self.mock_plan(params={})
-      {
+      StripeMock::Util.rmerge({
         interval: "month",
         name: "The Basic Plan",
         amount: 2300,
@@ -383,13 +383,13 @@ module StripeMock
         livemode: false,
         interval_count: 1,
         trial_period_days: nil
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_recipient(cards, params={})
       rp_id = params[:id] || "test_rp_default"
       cards.each {|card| card[:recipient] = rp_id}
-      {
+      StripeMock::Util.rmerge({
         name: "Stripe User",
         type: "individual",
         livemode: false,
@@ -412,7 +412,7 @@ module StripeMock
           total_count: cards.count
         },
         default_card: nil
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_recipient_array
@@ -424,7 +424,7 @@ module StripeMock
     end
 
     def self.mock_token(params={})
-      {
+      StripeMock::Util.rmerge({
         :id => 'tok_default',
         :livemode => false,
         :used => false,
@@ -450,12 +450,12 @@ module StripeMock
           :address_zip => nil,
           :address_country => nil
         }
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_transfer(params={})
       id = params[:id] || 'tr_test_transfer'
-      {
+      StripeMock::Util.rmerge({
         :status => 'pending',
         :amount => 100,
         :account => {
@@ -480,7 +480,7 @@ module StripeMock
           :has_more => false,
           :url => "/v1/transfers/#{id}/reversals"
         },
-      }.merge(params)
+      }, params)
     end
 
     def self.mock_transfer_array

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1,6 +1,96 @@
 module StripeMock
   module Data
 
+    def self.mock_account(params = {})
+      id = params[:id] || 'acct_103ED82ePvKYlo2C'
+      {
+        id: id,
+        email: "bob@example.com",
+        statement_descriptor: nil,
+        display_name: "Stripe.com",
+        timezone: "US/Pacific",
+        details_submitted: false,
+        charges_enabled: false,
+        transfers_enabled: false,
+        currencies_supported: [
+          "usd"
+        ],
+        default_currency: "usd",
+        country: "US",
+        object: "account",
+        business_name: "Stripe.com",
+        business_url: nil,
+        support_phone: nil,
+        managed: false,
+        product_description: nil,
+        debit_negative_balances: true,
+        bank_accounts: {
+          object: "list",
+          total_count: 0,
+          has_more: false,
+          url: "/v1/accounts/#{id}/bank_accounts",
+          data: [
+
+          ]
+        },
+        verification: {
+          fields_needed: [],
+          due_by: nil,
+          contacted: false
+        },
+        transfer_schedule: {
+          delay_days: 7,
+          interval: "daily"
+        },
+        tos_acceptance: {
+          ip: nil,
+          date: nil,
+          user_agent: nil
+        },
+        legal_entity: {
+          type: nil,
+          business_name: nil,
+          address: {
+            line1: nil,
+            line2: nil,
+            city: nil,
+            state: nil,
+            postal_code: nil,
+            country: "US"
+          },
+          first_name: nil,
+          last_name: nil,
+          personal_address: {
+            line1: nil,
+            line2: nil,
+            city: nil,
+            state: nil,
+            postal_code: nil,
+            country: nil
+          },
+          dob: {
+            day: nil,
+            month: nil,
+            year: nil
+          },
+          additional_owners: nil,
+          verification: {
+            status: "unverified",
+            document: nil,
+            details: nil
+          }
+        },
+        decline_charge_on: {
+          cvc_failure: false,
+          avs_failure: false
+        },
+        keys: {
+          secret: nil,
+          publishable: nil
+        }
+      }.merge(params)
+    end
+
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
       sources.each {|source| source[:customer] = cus_id}

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -18,6 +18,7 @@ module StripeMock
       @@handlers.find {|h| method_url =~ h[:route] }
     end
 
+    include StripeMock::RequestHandlers::Accounts
     include StripeMock::RequestHandlers::Charges
     include StripeMock::RequestHandlers::Cards
     include StripeMock::RequestHandlers::Sources
@@ -33,12 +34,13 @@ module StripeMock
     include StripeMock::RequestHandlers::Tokens
 
 
-    attr_reader :bank_tokens, :charges, :coupons, :customers, :events,
+    attr_reader :accounts, :bank_tokens, :charges, :coupons, :customers, :events,
                 :invoices, :invoice_items, :plans, :recipients, :transfers, :subscriptions
 
     attr_accessor :error_queue, :debug
 
     def initialize
+      @accounts = {}
       @bank_tokens = {}
       @card_tokens = {}
       @customers = {}

--- a/lib/stripe_mock/request_handlers/accounts.rb
+++ b/lib/stripe_mock/request_handlers/accounts.rb
@@ -1,0 +1,30 @@
+module StripeMock
+  module RequestHandlers
+    module Accounts
+
+      def Accounts.included(klass)
+        klass.add_handler 'post /v1/accounts',  :new_account
+        klass.add_handler 'get /v1/accounts/(.*)',  :get_account
+        klass.add_handler 'post /v1/accounts/(.*)',  :update_account
+      end
+
+      def new_account(route, method_url, params, headers)
+        params[:id] ||= new_id('acct')
+        route =~ method_url
+        accounts[ params[:id] ] ||= Data.mock_account(params)
+      end
+
+      def get_account(route, method_url, params, headers)
+        route =~ method_url
+        assert_existence :account, $1, accounts[$1]
+      end
+
+      def update_account(route, method_url, params, headers)
+        route =~ method_url
+        assert_existence :account, $1, accounts[$1]
+        accounts[$1].merge!(params)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the ability to mock Stripe::Account records (https://stripe.com/docs/api#account).

Included is a change to recursively merge hashes in other data mocks. We were not sure if it was an oversight or not that these were not recursively merged, but had a lot of issues where overriding specific nested parameters would cause method missing errors on the resulting objects.
