### PR TITLE
Custom "trial_end" gets overwritten on update

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -184,6 +184,7 @@ module StripeMock
         end
 
         params[:current_period_start] = subscription[:current_period_start]
+        params[:trial_end] = params[:trial_end] || subscription[:trial_end]
         subscription.merge!(custom_subscription_params(plan, customer, params))
 
         # delete the old subscription, replace with the new subscription


### PR DESCRIPTION
I originally created a subscription with a custom `trial_end` date, but when I update anything else on subscription without `trial_end` in the params it goes through this logic in subscription_helpers.rb

> end_time = options[:trial_end] || (Time.now.utc.to_i + plan[:trial_period_days]*86400)
>           params.merge!({status: 'trialing', current_period_end: end_time, trial_start: start_time, trial_end: end_time})