### PR TITLE
Add File Mock Support

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -70,6 +70,7 @@ require 'stripe_mock/request_handlers/subscriptions.rb'
 require 'stripe_mock/request_handlers/tokens.rb'
 require 'stripe_mock/request_handlers/country_spec.rb'
 require 'stripe_mock/request_handlers/ephemeral_key.rb'
+require 'stripe_mock/request_handlers/files.rb'
 require 'stripe_mock/instance'
 
 require 'stripe_mock/test_strategies/base.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1047,5 +1047,36 @@ module StripeMock
         secret: "ek_test_default"
       }
     end
+
+    def self.mock_file(params={})
+      id = params[:id] || 'file_1D2bNMG2b8EWj803MhNWqPw4'
+      {
+        id: id,
+        object: "file",
+        created: 1535102080,
+        filename: id,
+        links:
+        { object: "list",
+         data:
+          [{id: "link_1DLz0SG2b8EWj803yQ9arYOA",
+            object: "file_link",
+            created: 1539721148,
+            expired: false,
+            expires_at: nil,
+            file: id,
+            livemode: false,
+            metadata: {},
+            url: "https://files.stripe.com/links/fl_test_J5swDccota4TyeNpoGm9l5Nt"
+          }],
+         has_more: false,
+         url: "/v1/file_links?file=#{id}"
+        },
+        purpose: "dispute_evidence",
+        size: 9863,
+        title: nil,
+        type: "png",
+        url: "https://files.stripe.com/v1/files/#{id}/contents"
+      }
+    end
   end
 end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -43,10 +43,11 @@ module StripeMock
     include StripeMock::RequestHandlers::CountrySpec
     include StripeMock::RequestHandlers::Payouts
     include StripeMock::RequestHandlers::EphemeralKey
+    include StripeMock::RequestHandlers::Files
 
     attr_reader :accounts, :balance, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
                 :disputes, :events, :invoices, :invoice_items, :orders, :plans, :recipients,
-                :refunds, :transfers, :payouts, :subscriptions, :country_spec, :subscriptions_items
+                :refunds, :transfers, :payouts, :subscriptions, :country_spec, :subscriptions_items, :files
 
     attr_accessor :error_queue, :debug, :conversion_rate, :account_balance
 
@@ -72,6 +73,7 @@ module StripeMock
       @subscriptions = {}
       @subscriptions_items = []
       @country_spec = {}
+      @files = {}
 
       @debug = false
       @error_queue = ErrorQueue.new

--- a/lib/stripe_mock/request_handlers/files.rb
+++ b/lib/stripe_mock/request_handlers/files.rb
@@ -1,0 +1,27 @@
+module StripeMock
+  module RequestHandlers
+    module Files
+
+      def Files.included(klass)
+        klass.add_handler 'post /v1/files',            :new_file
+        klass.add_handler 'get /v1/files/(.*)',        :get_file
+        klass.add_handler 'get /v1/files',             :list_files
+      end
+
+      def new_file(route, method_url, params, headers)
+        id = new_id('file')
+        files[id] = Data.mock_file(params.merge :id => id)
+      end
+
+      def get_file(route, method_url, params, headers)
+        route =~ method_url
+        assert_existence :files, $1, files[$1]
+        files[$1] ||= Data.mock_file
+      end
+
+      def list_files(route, method_url, params, headers)
+        Data.mock_list_object(files.values, params)
+      end
+    end
+  end
+end

--- a/spec/shared_stripe_examples/files_examples.rb
+++ b/spec/shared_stripe_examples/files_examples.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+shared_examples 'Files API' do
+  describe 'Create a new File' do
+    it 'creates a new file' do
+      file = Stripe::File.create(purpose: 'dispute_evidence', file: '')
+      expect(file.object).to eq('file')
+      expect(file.purpose).to eq('dispute_evidence')
+    end
+  end
+
+  describe 'Retrieves a File' do
+    it 'retrieves a specific file' do
+      original = Stripe::File.create(purpose: 'dispute_evidence', file: '')
+      file = Stripe::File.retrieve(original.id)
+
+      expect(file).to be_a Stripe::File
+      expect(file.id).to match /file\_/
+    end
+  end
+
+  describe "listing payouts" do
+    before do
+      3.times do
+        Stripe::File.create(purpose: 'dispute_evidence', file: '')
+      end
+    end
+
+    it "without params retrieves all files" do
+      expect(Stripe::File.all.count).to eq(3)
+    end
+
+    it "accepts a limit param" do
+      expect(Stripe::File.all(limit: 2).count).to eq(2)
+    end
+  end
+end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -30,6 +30,7 @@ def it_behaves_like_stripe(&block)
   it_behaves_like 'Webhook Events API', &block
   it_behaves_like 'Country Spec API', &block
   it_behaves_like 'EphemeralKey API', &block
+  it_behaves_like 'Files API', &block
 
   # Integration tests
   it_behaves_like 'Multiple Customer Cards'


### PR DESCRIPTION
Resolves the following issue that came to light whilst working on another project. 

```ruby
Loading development environment (Rails 4.2.8)
[1] pry(main)> require 'stripe_mock'
=> true
[2] pry(main)> StripeMock.start
=> "local"
[3] pry(main)> res, api_key = StripeMock.instance.mock_request('post', '/v1/files', api_key: 'api_key', params: {})
[StripeMock] Warning : Unrecognized endpoint + method : [post /v1/files]
=> [{}, "api_key"]
[4] pry(main)>
```