### PR TITLE
Simulate Stripe card identifiers

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1,6 +1,5 @@
 module StripeMock
   module Data
-
     def self.mock_account(params = {})
       id = params[:id] || 'acct_103ED82ePvKYlo2C'
       currency = params[:currency] || StripeMock.default_currency
@@ -104,13 +103,13 @@ module StripeMock
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
       currency = params[:currency] || StripeMock.default_currency
-      sources.each {|source| source[:customer] = cus_id}
+      sources.each { |source| source[:customer] = cus_id }
       {
         email: 'stripe_mock@example.com',
         description: 'an auto-generated stripe customer data mock',
         object: "customer",
         created: 1372126710,
-        id: cus_id,
+        id: StripeMock::Util.card_id,
         livemode: false,
         delinquent: false,
         discount: nil,
@@ -153,6 +152,7 @@ module StripeMock
         statement_descriptor: "Charge #{charge_id}",
         status: 'succeeded',
         source: {
+          id: StripeMock::Util.card_id,
           object: "card",
           last4: "4242",
           type: "Visa",
@@ -222,7 +222,7 @@ module StripeMock
 
     def self.mock_card(params={})
       StripeMock::Util.card_merge({
-        id: "test_cc_default",
+        id: StripeMock::Util.card_id,
         object: "card",
         last4: "4242",
         type: "Visa",

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -11,7 +11,7 @@ module StripeMock
 
       def generate_card_token(card_params = {})
         token = new_id 'tok'
-        card_params[:id] = new_id 'cc'
+        card_params[:id] = StripeMock::Util.card_id
         @card_tokens[token] = Data.mock_card symbolize_names(card_params)
         token
       end

--- a/lib/stripe_mock/util.rb
+++ b/lib/stripe_mock/util.rb
@@ -29,6 +29,10 @@ module StripeMock
       Digest::SHA1.base64digest(source).gsub(/[^a-z]/i, '')[0..15]
     end
 
+    def self.card_id
+      "src_#{SecureRandom.hex(18)}"
+    end
+
     def self.card_merge(old_param, new_param)
       if new_param[:number] ||= old_param[:number]
         if new_param[:last4]
@@ -37,6 +41,7 @@ module StripeMock
           new_param[:last4] = new_param[:number][-4..-1]
         end
       end
+
       old_param.merge(new_param)
     end
 

--- a/lib/stripe_mock/version.rb
+++ b/lib/stripe_mock/version.rb
@@ -1,4 +1,4 @@
 module StripeMock
   # stripe-ruby-mock version
-  VERSION = "2.5.6"
+  VERSION = '2.5.7'
 end

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -7,6 +7,7 @@ shared_examples 'Card API' do
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
     card = customer.sources.create(source: card_token)
 
+    expect(card.id).to match(/src_\h+/)
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("1123")
     expect(card.exp_month).to eq(11)
@@ -15,6 +16,8 @@ shared_examples 'Card API' do
     customer = Stripe::Customer.retrieve('test_customer_sub')
     expect(customer.sources.count).to eq(1)
     card = customer.sources.data.first
+
+    expect(card.id).to match(/src_\h+/)
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("1123")
     expect(card.exp_month).to eq(11)
@@ -32,6 +35,7 @@ shared_examples 'Card API' do
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
     card = recipient.cards.create(card: card_token)
 
+    expect(card.id).to match(/src_\h+/)
     expect(card.recipient).to eq('test_recipient_sub')
     expect(card.last4).to eq("1123")
     expect(card.exp_month).to eq(11)
@@ -40,6 +44,8 @@ shared_examples 'Card API' do
     recipient = Stripe::Recipient.retrieve('test_recipient_sub')
     expect(recipient.cards.count).to eq(1)
     card = recipient.cards.data.first
+
+    expect(card.id).to match(/src_\h+/)
     expect(card.recipient).to eq('test_recipient_sub')
     expect(card.last4).to eq("1123")
     expect(card.exp_month).to eq(11)
@@ -55,6 +61,7 @@ shared_examples 'Card API' do
       cvc: '123'
     })
 
+    expect(card.id).to match(/src_\h+/)
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("4242")
     expect(card.exp_month).to eq(11)
@@ -63,6 +70,7 @@ shared_examples 'Card API' do
     customer = Stripe::Customer.retrieve('test_customer_sub')
     expect(customer.sources.count).to eq(1)
     card = customer.sources.data.first
+
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("4242")
     expect(card.exp_month).to eq(11)
@@ -83,6 +91,7 @@ shared_examples 'Card API' do
       cvc: '123'
     })
 
+    expect(card.id).to match(/src_\h+/)
     expect(card.recipient).to eq('test_recipient_sub')
     expect(card.last4).to eq("5556")
     expect(card.exp_month).to eq(11)
@@ -91,6 +100,8 @@ shared_examples 'Card API' do
     recipient = Stripe::Recipient.retrieve('test_recipient_sub')
     expect(recipient.cards.count).to eq(1)
     card = recipient.cards.data.first
+
+    expect(card.id).to match(/src_\h+/)
     expect(card.recipient).to eq('test_recipient_sub')
     expect(card.last4).to eq("5556")
     expect(card.exp_month).to eq(11)
@@ -113,7 +124,7 @@ shared_examples 'Card API' do
   it 'create does not change the customers default card if already set' do
     customer = Stripe::Customer.create(id: 'test_customer_sub', default_source: "test_cc_original")
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
-    card = customer.sources.create(source: card_token)
+    customer.sources.create(source: card_token)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
     expect(customer.default_source).to eq("test_cc_original")
@@ -122,7 +133,7 @@ shared_examples 'Card API' do
   it 'create updates the customers default card if not set' do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
-    card = customer.sources.create(source: card_token)
+    customer.sources.create(source: card_token)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
     expect(customer.default_source).to_not be_nil
@@ -262,13 +273,13 @@ shared_examples 'Card API' do
 
       retrieved = customer.sources.retrieve(card.id)
 
+      expect(retrieved.id).to match(/src_\h+/)
       expect(retrieved.exp_month).to eq(exp_month)
       expect(retrieved.exp_year).to eq(exp_year)
     end
   end
 
   context "retrieve multiple cards" do
-
     it "retrieves a list of multiple cards" do
       customer = Stripe::Customer.create(id: 'test_customer_card')
 
@@ -303,5 +314,4 @@ shared_examples 'Card API' do
       expect(list.data.length).to eq(0)
     end
   end
-
 end


### PR DESCRIPTION
This PR simulates correct Stripe card identifiers (e.g. prefixed with 'src_'), and also ensures that sources always have an ID attribute.