### PR TITLE
Support Payment Intent status requires_capture

### DIFF
--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -20,6 +20,7 @@ module StripeMock
         status = case params[:amount]
         when 3184 then 'requires_action'
         when 3178 then 'requires_payment_method'
+        when 3055 then 'requires_capture'
         else
           'succeeded'
         end

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -36,6 +36,16 @@ shared_examples 'PaymentIntent API' do
     expect(payment_intent.last_payment_error.message).to eq('Not enough funds.')
   end
 
+  it "creates a requires_payment_method stripe payment_intent when amount matches 3055" do
+    payment_intent = Stripe::PaymentIntent.create(amount: 3055, currency: "usd")
+
+    expect(payment_intent.id).to match(/^test_pi/)
+    expect(payment_intent.amount).to eq(3055)
+    expect(payment_intent.currency).to eq('usd')
+    expect(payment_intent.metadata.to_hash).to eq({})
+    expect(payment_intent.status).to eq('requires_capture')
+  end
+
   describe "listing payment_intent" do
     before do
       3.times do


### PR DESCRIPTION
In order to test separate auth and capture, one must be able to create payment intents with the status `requires_capture`.

Based on test card with 4 last 3055:

> 3D Secure authentication may still be performed, but is not required. By default, your Radar rules will not request 3D Secure authentication for this card.
– https://stripe.com/docs/testing#three-ds-cards