### PR TITLE
Update travis to only run on supported versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ group: deprecated-2017Q2
 sudo: required
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 before_install:
-  - rvm 2.1.10 do gem install mime-types -v 2.6.2
   - gem install bundler
 before_script:
   - "sudo touch /var/log/stripe-mock-server.log"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,10 +30,9 @@ RSpec.configure do |c|
     if ENV['IS_TRAVIS']
       puts "Travis ruby version: #{RUBY_VERSION}"
       api_key = case RUBY_VERSION
-      when '2.0.0'  then ENV['STRIPE_TEST_SECRET_KEY_A']
-      when '2.1.10' then ENV['STRIPE_TEST_SECRET_KEY_B']
-      when '2.2.7'  then ENV['STRIPE_TEST_SECRET_KEY_C']
-      when '2.3.4'  then ENV['STRIPE_TEST_SECRET_KEY_D']
+      when '2.4.6'  then ENV['STRIPE_TEST_SECRET_KEY_A']
+      when '2.5.5' then ENV['STRIPE_TEST_SECRET_KEY_B']
+      when '2.6.3'  then ENV['STRIPE_TEST_SECRET_KEY_C']
       end
     else
       api_key = ENV['STRIPE_TEST_SECRET_KEY']


### PR DESCRIPTION
I'd like to help get the test suite back into shape. I think the first step is to drop the old versions of ruby that are no longer supported from the travis config, since it's unlikely that anyone is actually using them. 

This PR updates the travis config to use the latest releases of ruby 2.4, 2.5 and 2.6, and remove a stray gem install that dates back to the ruby 1.9 era.

This doesn't fix the test suite, but I think it's a good first step.