### PR TITLE
Adds support for pending_invoice_item_interval

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -349,7 +349,9 @@ module StripeMock
         tax_percent: nil,
         discount: nil,
         metadata: {},
-        default_tax_rates: nil
+        default_tax_rates: nil,
+        pending_invoice_item_interval: nil,
+        next_pending_invoice_item_invoice: nil
       }, params)
     end
 

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -32,7 +32,7 @@ module StripeMock
         start_time = options[:current_period_start] || now
         params = { customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
-        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates/
+        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval/
         params.merge! options.select {|k,v| k =~ keys_to_merge}
 
         if options[:cancel_at_period_end] == true

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -102,7 +102,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -183,6 +183,20 @@ shared_examples 'Customer Subscriptions' do
       expect(subscription.tax_percent).to eq(20)
     end
 
+    it "correctly sets pending invoice item interval" do
+      customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk)
+
+      subscription = Stripe::Subscription.create({
+        plan: plan.id,
+        customer: customer.id,
+        quantity: 2,
+        pending_invoice_item_interval: { interval: 'month', interval_count: 1 }
+      })
+
+      expect(subscription.pending_invoice_item_interval.interval).to eq 'month'
+      expect(subscription.pending_invoice_item_interval.interval_count).to eq 1
+    end
+
     it "correctly sets created when it's not provided as a parameter", live: true do
       customer = Stripe::Customer.create(source: gen_card_tk)
       subscription = Stripe::Subscription.create({ plan: plan.id, customer: customer.id })
@@ -718,6 +732,26 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.save).to be_truthy
       expect(sub.cancel_at_period_end).to be_falsey
       expect(sub.canceled_at).to be_falsey
+    end
+
+    it "updates a subscription's pending invoice item interval" do
+      customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk)
+
+      subscription = Stripe::Subscription.create({
+        plan: plan.id,
+        customer: customer.id,
+        quantity: 2,
+        pending_invoice_item_interval: { interval: 'month', interval_count: 1 }
+      })
+
+      expect(subscription.pending_invoice_item_interval.interval).to eq 'month'
+      expect(subscription.pending_invoice_item_interval.interval_count).to eq 1
+
+      subscription.pending_invoice_item_interval = { interval: 'week', interval_count: 3 }
+      subscription.save
+
+      expect(subscription.pending_invoice_item_interval.interval).to eq 'week'
+      expect(subscription.pending_invoice_item_interval.interval_count).to eq 3
     end
 
     it 'when adds coupon', live: true do


### PR DESCRIPTION
* This feature allows a subscription to be modified
  but delays sending out the invoice for the new invoice items.

* For example you can update the subscription quanitity with
  `prorate: true` and allow the invoice items for the proration
  adjustment to be generated but rather than invoicing for those
  new items within a few hours they can accumulate and be invoiced
  all at once on a chosen cadence like once-per-month

* https://stripe.com/docs/api/subscriptions/object#subscription_object-pending_invoice_item_interval