### PR TITLE
Allow account update w no tos

### DIFF
--- a/lib/stripe_mock/request_handlers/accounts.rb
+++ b/lib/stripe_mock/request_handlers/accounts.rb
@@ -29,11 +29,7 @@ module StripeMock
         route =~ method_url
         account = assert_existence :account, $1, accounts[$1]
         account.merge!(params)
-        if blank_value?(params[:tos_acceptance], :date)
-          raise Stripe::InvalidRequestError.new("Invalid integer: ", "tos_acceptance[date]", http_status: 400)
-        elsif params[:tos_acceptance] && params[:tos_acceptance][:date]
-          validate_acceptance_date(params[:tos_acceptance][:date])
-        end
+        validate_acceptance_date(params[:tos_acceptance])
         account
       end
 
@@ -69,7 +65,10 @@ module StripeMock
         false
       end
 
-      def validate_acceptance_date(unix_date)
+      def validate_acceptance_date(tos_node)
+        return if tos_node.nil? || !tos_node.key?(:date)
+        raise Stripe::InvalidRequestError.new("Invalid integer: ", "tos_acceptance[date]", http_status: 400) if blank_value?(tos_node, :date)
+        unix_date = tos_node[:date]
         unix_now = Time.now.strftime("%s").to_i
         formatted_date = Time.at(unix_date)
 
@@ -77,7 +76,7 @@ module StripeMock
 
         raise Stripe::InvalidRequestError.new(
           "ToS acceptance date is not valid. Dates are expected to be integers, measured in seconds, not in the future, and after 2009",
-          "tos_acceptance[date]", 
+          "tos_acceptance[date]",
           http_status: 400
         )
       end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_stripe_examples
 
-describe 'StripeMock Server', :mock_server => true do
+describe 'StripeMock Server', ignore: true, :mock_server => true do
 
   let(:stripe_helper) { StripeMock.create_test_helper }
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_stripe_examples
 
-describe 'StripeMock Server', ignore: true, :mock_server => true do
+describe 'StripeMock Server', :mock_server => true do
 
   let(:stripe_helper) { StripeMock.create_test_helper }
 

--- a/spec/shared_stripe_examples/account_examples.rb
+++ b/spec/shared_stripe_examples/account_examples.rb
@@ -39,7 +39,7 @@ shared_examples 'Account API' do
       expect(account.external_accounts.url).to match /\/v1\/accounts\/.*\/external_accounts/
     end
   end
-  describe 'updates account' do
+  describe 'updates account', focus: true do
     it 'updates account' do
       account = Stripe::Account.retrieve
       account.support_phone = '1234567'
@@ -50,12 +50,20 @@ shared_examples 'Account API' do
       expect(account.support_phone).to eq '1234567'
     end
 
+    it 'doesnt mind if an update doesnt include tos when updating using Stripe::Account.update' do
+      account = Stripe::Account.retrieve
+      account_id = account.id
+      expect{
+        Stripe::Account.update(account_id, {company: {owners_provided: true}})
+      }.not_to raise_error
+    end
+
     it 'raises when sending an empty tos date' do
       account = Stripe::Account.retrieve
       account.tos_acceptance.date = nil
       expect {
         account.save
-      }.to raise_error
+      }.to raise_error(Stripe::InvalidRequestError)
     end
 
     context 'with tos acceptance date' do

--- a/spec/shared_stripe_examples/account_examples.rb
+++ b/spec/shared_stripe_examples/account_examples.rb
@@ -39,7 +39,7 @@ shared_examples 'Account API' do
       expect(account.external_accounts.url).to match /\/v1\/accounts\/.*\/external_accounts/
     end
   end
-  describe 'updates account', focus: true do
+  describe 'updates account' do
     it 'updates account' do
       account = Stripe::Account.retrieve
       account.support_phone = '1234567'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,5 +53,6 @@ RSpec.configure do |c|
   end
 
   c.filter_run focus: true
+  c.filter_run_excluding ignore: true
   c.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
If you call `Stripe::Account::Update('act_...', {some_update})` then stripe mock will fail because the code was expecting a `tos_acceptance` node. This allows you to interact with Stripe Mock as you would Stripe live