### PR TITLE
gemspec: add change,issue,source_code URL

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -10,7 +10,12 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
   gem.authors       = ["Gilbert"]
   gem.email         = "gilbertbgarza@gmail.com"
-  gem.homepage      = "https://github.com/rebelidealist/stripe-ruby-mock"
+  gem.homepage      = "https://github.com/stripe-ruby-mock/stripe-ruby-mock"
+  gem.metadata      = {
+    "bug_tracker_uri" => "https://github.com/stripe-ruby-mock/stripe-ruby-mock/issues",
+    "changelog_uri"   => "https://github.com/stripe-ruby-mock/stripe-ruby-mock/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/stripe-ruby-mock/stripe-ruby-mock"
+  }
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Following suggestion in https://github.com/stripe-ruby-mock/stripe-ruby-mock/pull/691 adds a changelog URL. Also the github repo owner/URL changed. I guess the authors and email, too?