### PR TITLE
Add `has_more` attribute to all ListObject instances

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -142,12 +142,14 @@ module StripeMock
         sources: {
           object: "list",
           total_count: sources.size,
+          has_more: false,
           url: "/v1/customers/#{cus_id}/sources",
           data: sources
         },
         subscriptions: {
           object: "list",
           total_count: 0,
+          has_more: false,
           url: "/v1/customers/#{cus_id}/subscriptions",
           data: []
         },
@@ -371,6 +373,7 @@ module StripeMock
         lines: {
           object: "list",
           total_count: lines.count,
+          has_more: false,
           url: "/v1/invoices/#{in_id}/lines",
           data: lines
         },
@@ -601,6 +604,7 @@ module StripeMock
           object: "list",
           url: "/v1/recipients/#{rp_id}/cards",
           data: cards,
+          has_more: false,
           total_count: cards.count
         },
         default_card: nil


### PR DESCRIPTION
This method is called in Stripe when using the `auto_paging_each`
ListObject method. Without this being in the mock data this method
doesn't work.

Steps to reproduce:

```
$ rails console test
irb> StripeMock.start
irb> Stripe.api_key = 'sk_test_...'
irb> h = StripeMock.create_test_helper
irb> customer = Stripe::Customer.create(source: h.generate_card_token)
irb> customer.subscriptions.auto_paging_each.map(&:id)
```