### PR TITLE
Fix travisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.5.5
   - 2.6.3
 before_install:
-  - rvm 2.1.10 do gem install mime-types -v 2.6.2
   - gem install bundler -v '< 2'
 before_script:
   - "sudo touch /var/log/stripe-mock-server.log"


### PR DESCRIPTION
travisCI configuration was broken and the tests were not running.

This change allows the tests to run, but the suite has 4 failing tests