### PR TITLE
update the balance API to respond with instant_available

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1008,6 +1008,16 @@ module StripeMock
               bitcoin_receiver: 1545182
             }
           }],
+        instant_available: [
+          {
+            currency: "usd",
+            amount: usd_balance,
+            source_types: {
+              card: 25907032203,
+              bank_account: 108476658,
+              bitcoin_receiver: 1545182
+            }
+          }],
         connect_reserved: [
           {
             currency: "usd",

--- a/lib/stripe_mock/webhook_fixtures/balance.available.json
+++ b/lib/stripe_mock/webhook_fixtures/balance.available.json
@@ -18,6 +18,12 @@
           "currency": "usd"
         }
       ],
+      "instant_available": [
+        {
+          "amount": 0,
+          "currency": "usd"
+        }
+      ],
       "livemode": false,
       "object": "balance"
     }

--- a/spec/shared_stripe_examples/balance_examples.rb
+++ b/spec/shared_stripe_examples/balance_examples.rb
@@ -8,4 +8,10 @@ shared_examples 'Balance API' do
     expect(balance.available[0].amount).to eq(2000)
   end
 
+  it "retrieves a stripe instant balance" do
+    StripeMock.set_account_balance(2000)
+    balance = Stripe::Balance.retrieve()
+    expect(balance.instant_available[0].amount).to eq(2000)
+  end
+
 end


### PR DESCRIPTION
This adds `instant_available` to the the Balance API response

The 4 tests that fail are also failing on master