### PR TITLE
Implement Stripe::Checkout::Session.retrieve

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -77,6 +77,7 @@ require 'stripe_mock/request_handlers/ephemeral_key.rb'
 require 'stripe_mock/request_handlers/products.rb'
 require 'stripe_mock/request_handlers/tax_rates.rb'
 require 'stripe_mock/request_handlers/checkout.rb'
+require 'stripe_mock/request_handlers/checkout_session.rb'
 require 'stripe_mock/instance'
 
 require 'stripe_mock/test_strategies/base.rb'

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -50,6 +50,7 @@ module StripeMock
     include StripeMock::RequestHandlers::EphemeralKey
     include StripeMock::RequestHandlers::TaxRates
     include StripeMock::RequestHandlers::Checkout
+    include StripeMock::RequestHandlers::Checkout::Session
 
     attr_reader :accounts, :balance, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
                 :disputes, :events, :invoices, :invoice_items, :orders, :payment_intents, :payment_methods,

--- a/lib/stripe_mock/request_handlers/checkout_session.rb
+++ b/lib/stripe_mock/request_handlers/checkout_session.rb
@@ -1,0 +1,16 @@
+module StripeMock
+  module RequestHandlers
+    module Checkout
+      module Session
+        def Session.included(klass)
+          klass.add_handler 'get /v1/checkout/sessions/(.*)', :get_checkout_session
+        end
+
+        def get_checkout_session(route, method_url, params, headers)
+          route =~ method_url
+          assert_existence :checkout_session, $1, checkout_sessions[$1]
+        end
+      end
+    end
+  end
+end

--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -97,8 +97,25 @@ module StripeMock
         }.merge(params)
       end
 
+      def create_checkout_session_params(params = {})
+        {
+            payment_method_types: ['card'],
+            line_items: [{
+                             name: 'T-shirt',
+                             quantity: 1,
+                             amount: 500,
+                             currency: 'usd',
+                         }],
+        }.merge(params)
+      end
+
+
       def create_coupon(params = {})
         Stripe::Coupon.create create_coupon_params(params)
+      end
+
+      def create_checkout_session(params = {})
+        Stripe::Checkout::Session.create create_checkout_session_params(params)
       end
 
       def delete_all_coupons

--- a/spec/shared_stripe_examples/checkout_examples.rb
+++ b/spec/shared_stripe_examples/checkout_examples.rb
@@ -15,5 +15,24 @@ shared_examples 'Checkout API' do
     expect(session.id).to match(/^test_cs/)
     expect(session.line_items.count).to eq(1)
   end
-  
+
+  context 'retrieve a checkout session' do
+    let(:checkout_session1) { stripe_helper.create_checkout_session }
+
+    it 'ca be retrieved by id' do
+      checkout_session1
+
+      checkout_session = Stripe::Checkout::Session.retrieve(checkout_session1.id)
+
+      expect(checkout_session.id).to eq(checkout_session1.id)
+    end
+
+    it "cannot retrieve a checkout session that doesn't exist" do
+      expect { Stripe::Checkout::Session.retrieve('nope') }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.param).to eq('checkout_session')
+        expect(e.http_status).to eq(404)
+      }
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a mock for the method in the title, which was missing.
Solves the warning:
`[StripeMock] Warning : Unrecognized endpoint + method : [get /v1/checkout/sessions/test_cs_XX]`