### PR TITLE
Adding account link mock

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -47,6 +47,7 @@ require 'stripe_mock/request_handlers/helpers/token_helpers.rb'
 
 require 'stripe_mock/request_handlers/validators/param_validators.rb'
 
+require 'stripe_mock/request_handlers/account_links.rb'
 require 'stripe_mock/request_handlers/accounts.rb'
 require 'stripe_mock/request_handlers/external_accounts.rb'
 require 'stripe_mock/request_handlers/balance.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -101,6 +101,16 @@ module StripeMock
       }.merge(params)
     end
 
+    def self.mock_account_link(params = {})
+      now = Time.now.to_i
+      {
+        object: 'account_link',
+        created: now,
+        expires_at: now + 300,
+        url: 'https://connect.stripe.com/setup/c/iB0ph1cPnRLY'
+      }.merge(params)
+    end
+
     def self.mock_tax_rate(params)
       {
         id: 'test_cus_default',

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -24,6 +24,7 @@ module StripeMock
     include StripeMock::RequestHandlers::PaymentMethods
     include StripeMock::RequestHandlers::SetupIntents
     include StripeMock::RequestHandlers::ExternalAccounts
+    include StripeMock::RequestHandlers::AccountLinks
     include StripeMock::RequestHandlers::Accounts
     include StripeMock::RequestHandlers::Balance
     include StripeMock::RequestHandlers::BalanceTransactions

--- a/lib/stripe_mock/request_handlers/account_links.rb
+++ b/lib/stripe_mock/request_handlers/account_links.rb
@@ -1,0 +1,15 @@
+module StripeMock
+  module RequestHandlers
+    module AccountLinks
+
+      def AccountLinks.included(klass)
+        klass.add_handler 'post /v1/account_links',      :new_account_link
+      end
+
+      def new_account_link(route, method_url, params, headers)
+        route =~ method_url
+        Data.mock_account_link(params)
+      end
+    end
+  end
+end

--- a/spec/shared_stripe_examples/account_link_examples.rb
+++ b/spec/shared_stripe_examples/account_link_examples.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+shared_examples 'Account Link API' do
+  describe 'create account link' do
+    it 'creates an account link' do
+      account_link = Stripe::AccountLink.create(
+        type: 'onboarding',
+        account: 'acct_103ED82ePvKYlo2C',
+        failure_url: 'https://stripe.com',
+        success_url: 'https://stripe.com'
+      )
+
+      expect(account_link).to be_a Stripe::AccountLink
+    end
+  end
+end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -5,6 +5,7 @@ end
 
 def it_behaves_like_stripe(&block)
   it_behaves_like 'Account API', &block
+  it_behaves_like 'Account Link API', &block
   it_behaves_like 'Balance API', &block
   it_behaves_like 'Balance Transaction API', &block
   it_behaves_like 'Bank Account Token Mocking', &block


### PR DESCRIPTION
Adding mocks for the [Account Links API](https://stripe.com/docs/api/account_links). This has a single `POST` endpoint `/v1/account_links`