### PR TITLE
Subscription API update (2019-10-17): start has been replaced with start_date

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -351,7 +351,7 @@ module StripeMock
         cancel_at_period_end: false,
         canceled_at: nil,
         ended_at: nil,
-        start: 1308595038,
+        start_date: 1308595038,
         object: 'subscription',
         trial_start: 1308595038,
         trial_end: 1308681468,


### PR DESCRIPTION
https://stripe.com/docs/upgrades#2019-10-17

> The start field on a subscription resource has been removed and is replaced by a start_date
> field which represents when the entire subscription started as opposed to when the current
> plan configuration started.