### PR TITLE
[Subscriptions] Add additional parameters

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -350,6 +350,7 @@ module StripeMock
         },
         cancel_at_period_end: false,
         canceled_at: nil,
+        collection_method: 'charge_automatically',
         ended_at: nil,
         start: 1308595038,
         object: 'subscription',

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -361,6 +361,7 @@ module StripeMock
         discount: nil,
         metadata: {},
         default_tax_rates: nil,
+        default_payment_method: nil,
         pending_invoice_item_interval: nil,
         next_pending_invoice_item_invoice: nil
       }, params)

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -32,7 +32,7 @@ module StripeMock
         start_time = options[:current_period_start] || now
         params = { customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
-        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval|default_payment_method/
+        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval|default_payment_method|collection_method/
         params.merge! options.select {|k,v| k =~ keys_to_merge}
 
         if options[:cancel_at_period_end] == true

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -32,7 +32,7 @@ module StripeMock
         start_time = options[:current_period_start] || now
         params = { customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
-        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval/
+        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due|default_tax_rates|pending_invoice_item_interval|default_payment_method/
         params.merge! options.select {|k,v| k =~ keys_to_merge}
 
         if options[:cancel_at_period_end] == true

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -102,7 +102,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method collection_method)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -102,7 +102,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)
@@ -276,6 +276,7 @@ module StripeMock
         return if customer[:invoice_settings][:default_payment_method]
         return if customer[:trial_end]
         return if params[:trial_end]
+        return if subscription[:default_payment_method]
 
         plan_trial_period_days = plan[:trial_period_days] || 0
         plan_has_trial = plan_trial_period_days != 0 || plan[:amount] == 0 || plan[:trial_end]

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -133,12 +133,14 @@ shared_examples 'Customer Subscriptions' do
         plan: 'silver',
         customer: customer,
         metadata: { foo: "bar", example: "yes" },
+        collection_method: 'send_invoice',
         default_payment_method: payment_method.id,
       )
 
       subscriptions = Stripe::Subscription.list(customer: customer.id)
       expect(subscriptions.count).to eq(1)
       expect(subscriptions.data.first.id).to eq(sub.id)
+      expect(subscriptions.data.first.collection_method).to eq('send_invoice')
       expect(subscriptions.data.first.default_payment_method).to eq(payment_method.id)
     end
 
@@ -808,9 +810,11 @@ shared_examples 'Customer Subscriptions' do
       Stripe::Subscription.update(
         subscription.id,
         default_payment_method: payment_method_sepa.id,
+        collection_method: 'send_invoice',
       )
       
       subscriptions = Stripe::Subscription.list(customer: customer)
+      expect(subscriptions.data.first.collection_method).to eq('send_invoice')
       expect(subscriptions.data.first.default_payment_method).to eq(payment_method_sepa.id)
     end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -117,6 +117,31 @@ shared_examples 'Customer Subscriptions' do
       expect(subscriptions.data.first.metadata.example).to eq( "yes" )
     end
 
+    it "adds a new subscription with payment method provided as default" do
+      plan
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      payment_method = Stripe::PaymentMethod.create(
+        type: 'card',
+        card: {
+          number: 4242_4242_4242_4242,
+          exp_month: 9,
+          exp_year: (Time.now.year + 5),
+          cvc: 999
+        }
+      )
+      sub = Stripe::Subscription.create(
+        plan: 'silver',
+        customer: customer,
+        metadata: { foo: "bar", example: "yes" },
+        default_payment_method: payment_method.id,
+      )
+
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.first.id).to eq(sub.id)
+      expect(subscriptions.data.first.default_payment_method).to eq(payment_method.id)
+    end
+
     it "adds a new subscription to customer (string/symbol agnostic)" do
       customer = Stripe::Customer.create(source: gen_card_tk)
       subscriptions = Stripe::Subscription.list(customer: customer.id)
@@ -752,6 +777,41 @@ shared_examples 'Customer Subscriptions' do
 
       expect(subscription.pending_invoice_item_interval.interval).to eq 'week'
       expect(subscription.pending_invoice_item_interval.interval_count).to eq 3
+    end
+
+    it "updates a subscription's default payment method" do
+      plan
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      payment_method_card = Stripe::PaymentMethod.create(
+        type: 'card',
+        card: {
+          number: 4242_4242_4242_4242,
+          exp_month: 9,
+          exp_year: (Time.now.year + 5),
+          cvc: 999
+        }
+      )
+      payment_method_sepa = Stripe::PaymentMethod.create(
+        type: 'sepa_debit',
+        sepa_debit: {iban: 'DE89370400440532013000'},
+      )
+      subscription = Stripe::Subscription.create(
+        plan: 'silver',
+        customer: customer,
+        metadata: { foo: "bar", example: "yes" },
+        default_payment_method: payment_method_card.id,
+      )
+      
+      subscriptions = Stripe::Subscription.list(customer: customer)
+      expect(subscriptions.data.first.default_payment_method).to eq(payment_method_card.id)
+
+      Stripe::Subscription.update(
+        subscription.id,
+        default_payment_method: payment_method_sepa.id,
+      )
+      
+      subscriptions = Stripe::Subscription.list(customer: customer)
+      expect(subscriptions.data.first.default_payment_method).to eq(payment_method_sepa.id)
     end
 
     it 'when adds coupon', live: true do


### PR DESCRIPTION
Supports `default_payment_method` and `collection_method` parameters for `Stripe::Subscription`

