### PR TITLE
Fix List initialize error with deleted records

### DIFF
--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -152,4 +152,27 @@ describe StripeMock::Data::List do
       expect { list.to_h }.to raise_error
     end
   end
+
+  context "with data containing records marked 'deleted'" do
+    let(:customer_data) { StripeMock.instance.customers.values }
+    let(:customers) do
+      customer_data.map { |datum| Stripe::Util.convert_to_stripe_object(datum) }
+    end
+
+    before do
+      StripeMock.instance.customers.clear
+      Stripe::Customer.create
+      Stripe::Customer.delete(Stripe::Customer.create.id)
+    end
+
+    it "does not raise error on initialization" do
+      expect { StripeMock::Data::List.new(customer_data) }.to_not raise_error
+      expect { StripeMock::Data::List.new(customers) }.to_not raise_error
+    end
+
+    it "omits records marked 'deleted'" do
+      expect(StripeMock::Data::List.new(customer_data).data.size).to eq(1)
+      expect(StripeMock::Data::List.new(customers).data.size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
When deleting records, the record is marked internally as deleted but
other data fields are cleared, including `created`. The deleted record
is passed to StripeMock::Data::List.new from their respective #list
methods, e.g. Stripe::Customer.list. The sorting of these records in
initialize raised an ArgumentError (comparison of Integer with nil
failed).

This fix addresses the issue by omitting deleted records from the data
as that seems to be the more intuitive behavior. Minor refactoring was
also performed to normalize the sorting of data whether it is in Hash
or StripeObject form.