### PR TITLE
Set default invoice tax as zero

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -399,7 +399,7 @@ module StripeMock
         paid: false,
         receipt_number: nil,
         statement_descriptor: nil,
-        tax: 10,
+        tax: nil,
         tax_percent: nil,
         webhooks_delivered_at: 1349825350,
         livemode: false,


### PR DESCRIPTION
The default tax value on mock invoices was causing me issues when trying to test the total before tax of an stripe invoice in my app. The default tax value of 10 seems to me to be completely arbitrary, as there are no associated tax objects on the default mock invoice, and also because tax values are not accounted for in the calculation for the mock invoice total. 

Also, real stripe objects seem to have the ```tax``` and ```tax_percent``` fields always set simultaneously.

Seems to me to make more sense to set this value to nil. 

Thanks