### PR TITLE
Adds some basic call/response mocking of refunds for payment intents

### DIFF
--- a/lib/stripe_mock/request_handlers/refunds.rb
+++ b/lib/stripe_mock/request_handlers/refunds.rb
@@ -18,7 +18,18 @@ module StripeMock
           end
         end
 
-        charge = assert_existence :charge, params[:charge], charges[params[:charge]]
+        if params[:payment_intent]
+          payment_intent = assert_existence(
+            :payment_intent,
+            params[:payment_intent],
+            payment_intents[params[:payment_intent]]
+          )
+          charge = {}
+        else
+          charge = assert_existence :charge, params[:charge], charges[params[:charge]]
+          payment_intent = {}
+        end
+        params[:amount] ||= payment_intent[:amount]
         params[:amount] ||= charge[:amount]
         id = new_id('re')
         bal_trans_params = {
@@ -32,7 +43,7 @@ module StripeMock
           :id => id,
           :charge => charge[:id],
         )
-        add_refund_to_charge(refund, charge)
+        add_refund_to_charge(refund, charge) unless charge.empty?
         refunds[id] = refund
 
         if params[:expand] == ['balance_transaction']

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -22,6 +22,19 @@ shared_examples 'Refund API' do
       expect(charge.amount_refunded).to eq(999)
     end
 
+    it "refunds a stripe payment intent" do
+      payment_intent = Stripe::PaymentIntent.create(
+        amount: 999,
+        currency: 'USD'
+      )
+
+      refund = Stripe::Refund.create(
+        payment_intent: payment_intent.id
+      )
+      expect(refund.amount).to eq(999)
+    end
+
+
     it "creates a stripe refund with a status" do
       charge = Stripe::Charge.create(
         amount: 999,


### PR DESCRIPTION
* Does not link refunds through charges like I would expect because
  creation of payment intents do not seem to create and/or link charges

Fixes #714 