### PR TITLE
[Data] Add data to account links

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -107,7 +107,8 @@ module StripeMock
         object: 'account_link',
         created: now,
         expires_at: now + 300,
-        url: 'https://connect.stripe.com/setup/c/iB0ph1cPnRLY'
+        url: 'https://connect.stripe.com/setup/c/iB0ph1cPnRLY',
+        data: {}
       }.merge(params)
     end
 


### PR DESCRIPTION
```
Stripe::AccountLink.create({
  account: "mocked-email@email.com",
  refresh_url: "https://example.com/reauth",
  return_url: "https://example.com/return",
  type: "account_onboarding"
})
```
Will throw `NoMethodError: undefined method 'data' for {}:Hash` when testing with `stripe-ruby-mock`.

Adding empty `data` hash to `mock_account_link` fixes the error. 