### PR TITLE
include charge payment_method_details from api docs

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1,8 +1,7 @@
 module StripeMock
   module Data
-
     def self.mock_account(params = {})
-      id = params[:id] || 'acct_103ED82ePvKYlo2C'
+      id = params[:id] || "acct_103ED82ePvKYlo2C"
       currency = params[:currency] || StripeMock.default_currency
       {
         id: id,
@@ -30,9 +29,7 @@ module StripeMock
           total_count: 0,
           has_more: false,
           url: "/v1/accounts/#{id}/bank_accounts",
-          data: [
-
-          ]
+          data: []
         },
         verification: {
           fields_needed: [],
@@ -49,13 +46,11 @@ module StripeMock
           user_agent: nil
         },
         external_accounts: {
-            object: "list",
-            data: [
-
-            ],
-            has_more: false,
-            total_count: 0,
-            url: "/v1/accounts/#{id}/external_accounts"
+          object: "list",
+          data: [],
+          has_more: false,
+          total_count: 0,
+          url: "/v1/accounts/#{id}/external_accounts"
         },
         legal_entity: {
           type: nil,
@@ -101,26 +96,16 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_account_link(params = {})
-      now = Time.now.to_i
-      {
-        object: 'account_link',
-        created: now,
-        expires_at: now + 300,
-        url: 'https://connect.stripe.com/setup/c/iB0ph1cPnRLY'
-      }.merge(params)
-    end
-
     def self.mock_tax_rate(params)
       {
-        id: 'test_cus_default',
-        object: 'tax_rate',
+        id: "test_cus_default",
+        object: "tax_rate",
         active: true,
         created: 1559079603,
         description: nil,
-        display_name: 'VAT',
+        display_name: "VAT",
         inclusive: false,
-        jurisdiction: 'EU',
+        jurisdiction: "EU",
         livemode: false,
         metadata: {},
         percentage: 21.0
@@ -130,10 +115,10 @@ module StripeMock
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
       currency = params[:currency] || StripeMock.default_currency
-      sources.each {|source| source[:customer] = cus_id}
+      sources.each { |source| source[:customer] = cus_id }
       {
-        email: 'stripe_mock@example.com',
-        description: 'an auto-generated stripe customer data mock',
+        email: "stripe_mock@example.com",
+        description: "an auto-generated stripe customer data mock",
         object: "customer",
         created: 1372126710,
         id: cus_id,
@@ -152,14 +137,12 @@ module StripeMock
         sources: {
           object: "list",
           total_count: sources.size,
-          has_more: false,
           url: "/v1/customers/#{cus_id}/sources",
           data: sources
         },
         subscriptions: {
           object: "list",
           total_count: 0,
-          has_more: false,
           url: "/v1/customers/#{cus_id}/subscriptions",
           data: []
         },
@@ -167,7 +150,7 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_charge(params={})
+    def self.mock_charge(params = {})
       charge_id = params[:id] || "ch_1fD6uiR9FAA2zc"
       currency = params[:currency] || StripeMock.default_currency
       {
@@ -178,16 +161,36 @@ module StripeMock
         paid: true,
         amount: 0,
         application_fee: nil,
-        application_fee_amount: nil,
         currency: currency,
         destination: nil,
         fraud_details: {},
+        payment_method_details: {
+          card: {
+            brand: "visa",
+            checks: {
+              address_line1_check: nil,
+              address_postal_code_check: nil,
+              cvc_check: "pass"
+            },
+            country: "US",
+            exp_month: 12,
+            exp_year: 2013,
+            fingerprint: "3TQGpK9JoY1GgXPw",
+            funding: "credit",
+            installments: nil,
+            last4: "4242",
+            network: "visa",
+            three_d_secure: nil,
+            wallet: nil
+          },
+          type: "card"
+        },
         receipt_email: nil,
         receipt_number: nil,
         refunded: false,
         shipping: {},
         statement_descriptor: "Charge #{charge_id}",
-        status: 'succeeded',
+        status: "succeeded",
         source: {
           object: "card",
           last4: "4242",
@@ -231,7 +234,7 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_refund(params={})
+    def self.mock_refund(params = {})
       currency = params[:currency] || StripeMock.default_currency
       {
         id: "re_4fWhgUh5si7InF",
@@ -250,13 +253,13 @@ module StripeMock
 
     def self.mock_charge_array
       {
-        :data => [test_charge, test_charge, test_charge],
-        :object => 'list',
-        :url => '/v1/charges'
+        data: [test_charge, test_charge, test_charge],
+        object: "list",
+        url: "/v1/charges"
       }
     end
 
-    def self.mock_card(params={})
+    def self.mock_card(params = {})
       StripeMock::Util.card_merge({
         id: "test_cc_default",
         object: "card",
@@ -284,64 +287,64 @@ module StripeMock
       }, params)
     end
 
-    def self.mock_bank_account(params={})
+    def self.mock_bank_account(params = {})
       currency = params[:currency] || StripeMock.default_currency
       {
         id: "test_ba_default",
         object: "bank_account",
         bank_name: "STRIPEMOCK TEST BANK",
         last4: "6789",
-        routing_number: '110000000',
+        routing_number: "110000000",
         country: "US",
         currency: currency,
         validated: false,
-        status: 'new',
-        account_holder_name: 'John Doe',
-        account_holder_type: 'individual',
+        status: "new",
+        account_holder_name: "John Doe",
+        account_holder_type: "individual",
         fingerprint: "aBcFinGerPrINt123",
         metadata: {}
       }.merge(params)
     end
 
-    def self.mock_coupon(params={})
+    def self.mock_coupon(params = {})
       {
-        :duration_in_months => 3,
-        :percent_off => 25,
-        :amount_off => nil,
-        :currency => nil,
-        :id => "co_test_coupon",
-        :object => "coupon",
-        :max_redemptions => nil,
-        :redeem_by => nil,
-        :times_redeemed => 0,
-        :valid => true,
-        :metadata => {},
+        duration_in_months: 3,
+        percent_off: 25,
+        amount_off: nil,
+        currency: nil,
+        id: "co_test_coupon",
+        object: "coupon",
+        max_redemptions: nil,
+        redeem_by: nil,
+        times_redeemed: 0,
+        valid: true,
+        metadata: {}
       }.merge(params)
     end
 
-    #FIXME nested overrides would be better than hardcoding plan_id
-    def self.mock_subscription(params={})
+    # FIXME nested overrides would be better than hardcoding plan_id
+    def self.mock_subscription(params = {})
       StripeMock::Util.rmerge({
         created: 1478204116,
-        billing: 'charge_automatically',
+        billing: "charge_automatically",
         current_period_start: 1308595038,
         current_period_end: 1308681468,
-        status: 'trialing',
+        status: "trialing",
         trial_from_plan: false,
         plan: {
-          interval: 'month',
+          interval: "month",
           amount: 7500,
           trial_period_days: 30,
-          object: 'plan',
-          id: '__test_plan_id__'
+          object: "plan",
+          id: "__test_plan_id__"
         },
         items: {
-          object: 'list',
+          object: "list",
           data: [{
-            id: 'si_1AwFf62eZvKYlo2C9u6Dhf9',
+            id: "si_1AwFf62eZvKYlo2C9u6Dhf9",
             created: 1504035973,
             metadata: {},
-            object: 'subscription_item',
+            object: "subscription_item",
             plan: {
               amount: 999,
               created: 1504035972,
@@ -352,33 +355,31 @@ module StripeMock
         },
         cancel_at_period_end: false,
         canceled_at: nil,
-        collection_method: 'charge_automatically',
         ended_at: nil,
         start: 1308595038,
-        object: 'subscription',
+        object: "subscription",
         trial_start: 1308595038,
         trial_end: 1308681468,
-        customer: 'c_test_customer',
+        customer: "c_test_customer",
         quantity: 1,
         tax_percent: nil,
         discount: nil,
         metadata: {},
         default_tax_rates: nil,
-        default_payment_method: nil,
         pending_invoice_item_interval: nil,
         next_pending_invoice_item_invoice: nil
       }, params)
     end
 
-    def self.mock_invoice(lines, params={})
+    def self.mock_invoice(lines, params = {})
       in_id = params[:id] || "test_in_default"
       currency = params[:currency] || StripeMock.default_currency
-      lines << Data.mock_line_item() if lines.empty?
+      lines << Data.mock_line_item if lines.empty?
       invoice = {
-        id: 'in_test_invoice',
-        status: 'open',
-        invoice_pdf: 'pdf_url',
-        hosted_invoice_url: 'hosted_invoice_url',
+        id: "in_test_invoice",
+        status: "open",
+        invoice_pdf: "pdf_url",
+        hosted_invoice_url: "hosted_invoice_url",
         created: 1349738950,
         period_end: 1349738950,
         period_start: 1349738950,
@@ -386,13 +387,12 @@ module StripeMock
         lines: {
           object: "list",
           total_count: lines.count,
-          has_more: false,
           url: "/v1/invoices/#{in_id}/lines",
           data: lines
         },
-        subtotal: lines.map {|line| line[:amount]}.reduce(0, :+),
+        subtotal: lines.map { |line| line[:amount] }.reduce(0, :+),
         customer: "test_customer",
-        object: 'invoice',
+        object: "invoice",
         attempted: false,
         application_fee: nil,
         closed: false,
@@ -477,27 +477,27 @@ module StripeMock
 
     def self.mock_paid_invoice
       test_invoice.merge({
-          :attempt_count => 1,
-          :attempted => true,
-          :closed => true,
-          :paid => true,
-          :charge => 'ch_test_charge',
-          :ending_balance => 0,
-          :next_payment_attempt => nil,
-        })
+        attempt_count: 1,
+        attempted: true,
+        closed: true,
+        paid: true,
+        charge: "ch_test_charge",
+        ending_balance: 0,
+        next_payment_attempt: nil
+      })
     end
 
     def self.mock_invoice_customer_array
       {
-        :data => [test_invoice],
-        :object => 'list',
-        :url => '/v1/invoices?customer=test_customer'
+        data: [test_invoice],
+        object: "list",
+        url: "/v1/invoices?customer=test_customer"
       }
     end
 
     def self.mock_order(order_items, params)
       or_id = params[:id] || "test_or_default"
-      currency = params[:currency] || 'eur'
+      currency = params[:currency] || "eur"
       order_items << Data.mock_order_item if order_items.empty?
       {
         id: or_id,
@@ -532,8 +532,8 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_order_item(params={})
-      currency = params[:currency] || 'eur'
+    def self.mock_order_item(params = {})
+      currency = params[:currency] || "eur"
       {
         object: "order_item",
         amount: 5000,
@@ -545,7 +545,7 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_plan(params={})
+    def self.mock_plan(params = {})
       currency = params[:currency] || StripeMock.default_currency
       {
         id: "mock_plan_123",
@@ -570,12 +570,12 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_product(params={})
+    def self.mock_product(params = {})
       {
         id: "mock_prod_abc123",
         object: "product",
         active: true,
-        attributes:[],
+        attributes: [],
         caption: nil,
         created: 1466698000,
         deactivate_on: [],
@@ -594,9 +594,9 @@ module StripeMock
       }.merge(params)
     end
 
-    def self.mock_recipient(cards, params={})
+    def self.mock_recipient(cards, params = {})
       rp_id = params[:id] || "test_rp_default"
-      cards.each {|card| card[:recipient] = rp_id}
+      cards.each { |card| card[:recipient] = rp_id }
       {
         name: "Stripe User",
         type: "individual",
@@ -617,7 +617,6 @@ module StripeMock
           object: "list",
           url: "/v1/recipients/#{rp_id}/cards",
           data: cards,
-          has_more: false,
           total_count: cards.count
         },
         default_card: nil
@@ -626,179 +625,179 @@ module StripeMock
 
     def self.mock_recipient_array
       {
-        :data => [test_recipient, test_recipient, test_recipient],
-        :object => 'list',
-        :url => '/v1/recipients'
+        data: [test_recipient, test_recipient, test_recipient],
+        object: "list",
+        url: "/v1/recipients"
       }
     end
 
-    def self.mock_card_token(params={})
+    def self.mock_card_token(params = {})
       {
-        :id => 'tok_default',
-        :livemode => false,
-        :used => false,
-        :object => 'token',
-        :type => 'card',
-        :card => {
-          :id => 'card_default',
-          :object => 'card',
-          :last4 => '2222',
-          :type => 'Visa',
-          :brand => 'Visa',
-          :funding => 'credit',
-          :exp_month => 9,
-          :exp_year => 2017,
-          :fingerprint => 'JRRLXGh38NiYygM7',
-          :customer => nil,
-          :country => 'US',
-          :name => nil,
-          :address_line1 => nil,
-          :address_line2 => nil,
-          :address_city => nil,
-          :address_state => nil,
-          :address_zip => nil,
-          :address_country => nil
+        id: "tok_default",
+        livemode: false,
+        used: false,
+        object: "token",
+        type: "card",
+        card: {
+          id: "card_default",
+          object: "card",
+          last4: "2222",
+          type: "Visa",
+          brand: "Visa",
+          funding: "credit",
+          exp_month: 9,
+          exp_year: 2017,
+          fingerprint: "JRRLXGh38NiYygM7",
+          customer: nil,
+          country: "US",
+          name: nil,
+          address_line1: nil,
+          address_line2: nil,
+          address_city: nil,
+          address_state: nil,
+          address_zip: nil,
+          address_country: nil
         }
       }.merge(params)
     end
 
-    def self.mock_bank_account_token(params={})
+    def self.mock_bank_account_token(params = {})
       {
-        :id => 'tok_default',
-        :livemode => false,
-        :used => false,
-        :object => 'token',
-        :type => 'bank_account',
-        :bank_account => {
-          :id => 'bank_account_default',
-          :object => 'bank_account',
-          :last4 => '2222',
-          :fingerprint => 'JRRLXGh38NiYygM7',
+        id: "tok_default",
+        livemode: false,
+        used: false,
+        object: "token",
+        type: "bank_account",
+        bank_account: {
+          id: "bank_account_default",
+          object: "bank_account",
+          last4: "2222",
+          fingerprint: "JRRLXGh38NiYygM7"
         }
       }.merge(params)
     end
 
-    def self.mock_transfer(params={})
+    def self.mock_transfer(params = {})
       currency = params[:currency] || StripeMock.default_currency
-      id = params[:id] || 'tr_test_transfer'
+      id = params[:id] || "tr_test_transfer"
       {
-        :amount => 100,
-        :amount_reversed => 0,
-        :balance_transaction => "txn_2dyYXXP90MN26R",
-        :id => id,
-        :livemode => false,
-        :metadata => {},
-        :currency => currency,
-        :object => "transfer",
-        :created => 1304114826,
-        :description => "Transfer description",
-        :reversed => false,
-        :reversals => {
-          :object => "list",
-          :data => [],
-          :total_count => 0,
-          :has_more => false,
-          :url => "/v1/transfers/#{id}/reversals"
+        amount: 100,
+        amount_reversed: 0,
+        balance_transaction: "txn_2dyYXXP90MN26R",
+        id: id,
+        livemode: false,
+        metadata: {},
+        currency: currency,
+        object: "transfer",
+        created: 1304114826,
+        description: "Transfer description",
+        reversed: false,
+        reversals: {
+          object: "list",
+          data: [],
+          total_count: 0,
+          has_more: false,
+          url: "/v1/transfers/#{id}/reversals"
         },
-        :destination => "acct_164wxjKbnvuxQXGu",
-        :destination_payment => "py_164xRvKbnvuxQXGuVFV2pZo1",
-        :source_transaction => "ch_164xRv2eZvKYlo2Clu1sIJWB",
-        :source_type => "card",
-        :transfer_group => "group_ch_164xRv2eZvKYlo2Clu1sIJWB",
+        destination: "acct_164wxjKbnvuxQXGu",
+        destination_payment: "py_164xRvKbnvuxQXGuVFV2pZo1",
+        source_transaction: "ch_164xRv2eZvKYlo2Clu1sIJWB",
+        source_type: "card",
+        transfer_group: "group_ch_164xRv2eZvKYlo2Clu1sIJWB"
       }.merge(params)
     end
 
-    def self.mock_payout(params={})
+    def self.mock_payout(params = {})
       currency = params[:currency] || StripeMock.default_currency
-      id = params[:id] || 'po_test_payout'
+      id = params[:id] || "po_test_payout"
       {
-        :amount => 100,
-        :id => id,
-        :livemode => false,
-        :metadata => {},
-        :currency => currency,
-        :object => "payout",
-        :date => 1304114826,
-        :description => "Payout description",
+        amount: 100,
+        id: id,
+        livemode: false,
+        metadata: {},
+        currency: currency,
+        object: "payout",
+        date: 1304114826,
+        description: "Payout description"
       }.merge(params)
     end
 
-    def self.mock_disputes(ids=[])
+    def self.mock_disputes(ids = [])
       disputes = {}
       ids.each do |id|
-        disputes[id] = self.mock_dispute(id: id)
+        disputes[id] = mock_dispute(id: id)
       end
       disputes
     end
 
-    def self.mock_dispute(params={})
+    def self.mock_dispute(params = {})
       @timestamp ||= Time.now.to_i
       currency = params[:currency] || StripeMock.default_currency
       id = params[:id] || "dp_test_dispute"
       {
-        :id => id,
-        :object => "dispute",
-        :amount => 195,
-        :balance_transactions => [],
-        :charge => "ch_15RsQR2eZvKYlo2CA8IfzCX0",
-        :created => @timestamp += 1,
-        :currency => currency,
-        :evidence => self.mock_dispute_evidence,
-        :evidence_details => self.mock_dispute_evidence_details,
-        :is_charge_refundable => false,
-        :livemode => false,
-        :metadata => {},
-        :reason => "general",
-        :status => "under_review"
+        id: id,
+        object: "dispute",
+        amount: 195,
+        balance_transactions: [],
+        charge: "ch_15RsQR2eZvKYlo2CA8IfzCX0",
+        created: @timestamp += 1,
+        currency: currency,
+        evidence: mock_dispute_evidence,
+        evidence_details: mock_dispute_evidence_details,
+        is_charge_refundable: false,
+        livemode: false,
+        metadata: {},
+        reason: "general",
+        status: "under_review"
       }.merge(params)
     end
 
     def self.mock_dispute_evidence
       {
-        :access_activity_log => nil,
-        :billing_address => nil,
-        :cancellation_policy => nil,
-        :cancellation_policy_disclosure => nil,
-        :cancellation_rebuttal => nil,
-        :customer_communication => nil,
-        :customer_email_address => nil,
-        :customer_name => nil,
-        :customer_purchase_ip => nil,
-        :customer_signature => nil,
-        :duplicate_charge_documentation => nil,
-        :duplicate_charge_explanation => nil,
-        :duplicate_charge_id => nil,
-        :product_description => nil,
-        :receipt => nil,
-        :refund_policy => nil,
-        :refund_policy_disclosure => nil,
-        :refund_refusal_explanation => nil,
-        :service_date => nil,
-        :service_documentation => nil,
-        :shipping_address => nil,
-        :shipping_carrier => nil,
-        :shipping_date => nil,
-        :shipping_documentation => nil,
-        :shipping_tracking_number => nil,
-        :uncategorized_file => nil,
-        :uncategorized_text => nil
+        access_activity_log: nil,
+        billing_address: nil,
+        cancellation_policy: nil,
+        cancellation_policy_disclosure: nil,
+        cancellation_rebuttal: nil,
+        customer_communication: nil,
+        customer_email_address: nil,
+        customer_name: nil,
+        customer_purchase_ip: nil,
+        customer_signature: nil,
+        duplicate_charge_documentation: nil,
+        duplicate_charge_explanation: nil,
+        duplicate_charge_id: nil,
+        product_description: nil,
+        receipt: nil,
+        refund_policy: nil,
+        refund_policy_disclosure: nil,
+        refund_refusal_explanation: nil,
+        service_date: nil,
+        service_documentation: nil,
+        shipping_address: nil,
+        shipping_carrier: nil,
+        shipping_date: nil,
+        shipping_documentation: nil,
+        shipping_tracking_number: nil,
+        uncategorized_file: nil,
+        uncategorized_text: nil
       }
     end
 
     def self.mock_dispute_evidence_details
       {
-        :due_by => 1424303999,
-        :has_evidence => false,
-        :past_due => false,
-        :submission_count => 0
+        due_by: 1424303999,
+        has_evidence: false,
+        past_due: false,
+        submission_count: 0
       }
     end
 
     def self.mock_transfer_array
       {
-        :data => [test_transfer, test_transfer, test_transfer],
-        :object => 'list',
-        :url => '/v1/transfers'
+        data: [test_transfer, test_transfer, test_transfer],
+        object: "list",
+        url: "/v1/transfers"
       }
     end
 
@@ -824,15 +823,15 @@ module StripeMock
 
     def self.mock_missing_id_error
       {
-        :error => {
-          :param => "id",
-          :type => "invalid_request_error",
-          :message => "Missing id"
+        error: {
+          param: "id",
+          type: "invalid_request_error",
+          message: "Missing id"
         }
       }
     end
 
-    def self.mock_delete_subscription(params={})
+    def self.mock_delete_subscription(params = {})
       {
         deleted: true
       }.merge(params)
@@ -840,20 +839,20 @@ module StripeMock
 
     def self.mock_api_error
       {
-        :error => {
-          :type => "api_error"
+        error: {
+          type: "api_error"
         }
       }
     end
 
     def self.mock_delete_discount_response
       {
-        :deleted => true,
-        :id => "di_test_coupon"
+        deleted: true,
+        id: "di_test_coupon"
       }
     end
 
-    def self.mock_list_object(data, params={})
+    def self.mock_list_object(data, params = {})
       list = StripeMock::Data::List.new(data, params)
       list.to_h
     end
@@ -861,11 +860,11 @@ module StripeMock
     def self.mock_country_spec(country_code)
       id = country_code || "US"
       {
-        "id"=> "US",
-        "object"=> "country_spec",
-        "default_currency"=> "usd",
-        "supported_bank_account_currencies"=> {"usd"=>["US"]},
-        "supported_payment_currencies"=> [
+        "id" => "US",
+        "object" => "country_spec",
+        "default_currency" => "usd",
+        "supported_bank_account_currencies" => {"usd" => ["US"]},
+        "supported_payment_currencies" => [
           "usd",
           "aed",
           "afn",
@@ -1003,12 +1002,12 @@ module StripeMock
           "zar",
           "zmw"
         ],
-        "supported_payment_methods"=> [
+        "supported_payment_methods" => [
           "alipay",
           "card",
           "stripe"
         ],
-        "verification_fields"=> {"individual"=>{"minimum"=>["external_account","legal_entity.address.city","legal_entity.address.line1","legal_entity.address.postal_code","legal_entity.address.state","legal_entity.dob.day","legal_entity.dob.month","legal_entity.dob.year","legal_entity.first_name","legal_entity.last_name","legal_entity.personal_id_number","legal_entity.ssn_last_4","legal_entity.type","tos_acceptance.date","tos_acceptance.ip"],"additional"=>["legal_entity.personal_id_number","legal_entity.verification.document"]},"company"=>{"minimum"=>["external_account","legal_entity.address.city","legal_entity.address.line1","legal_entity.address.postal_code","legal_entity.address.state","legal_entity.business_name","legal_entity.business_tax_id","legal_entity.dob.day","legal_entity.dob.month","legal_entity.dob.year","legal_entity.first_name","legal_entity.last_name","legal_entity.ssn_last_4","legal_entity.type","tos_acceptance.date","tos_acceptance.ip"],"additional"=>["legal_entity.personal_id_number","legal_entity.verification.document"]}}
+        "verification_fields" => {"individual" => {"minimum" => ["external_account", "legal_entity.address.city", "legal_entity.address.line1", "legal_entity.address.postal_code", "legal_entity.address.state", "legal_entity.dob.day", "legal_entity.dob.month", "legal_entity.dob.year", "legal_entity.first_name", "legal_entity.last_name", "legal_entity.personal_id_number", "legal_entity.ssn_last_4", "legal_entity.type", "tos_acceptance.date", "tos_acceptance.ip"], "additional" => ["legal_entity.personal_id_number", "legal_entity.verification.document"]}, "company" => {"minimum" => ["external_account", "legal_entity.address.city", "legal_entity.address.line1", "legal_entity.address.postal_code", "legal_entity.address.state", "legal_entity.business_name", "legal_entity.business_tax_id", "legal_entity.dob.day", "legal_entity.dob.month", "legal_entity.dob.year", "legal_entity.first_name", "legal_entity.last_name", "legal_entity.ssn_last_4", "legal_entity.type", "tos_acceptance.date", "tos_acceptance.ip"], "additional" => ["legal_entity.personal_id_number", "legal_entity.verification.document"]}}
       }
     end
 
@@ -1024,22 +1023,14 @@ module StripeMock
               bank_account: 108476658,
               bitcoin_receiver: 1545182
             }
-          }],
-        instant_available: [
-          {
-            currency: "usd",
-            amount: usd_balance,
-            source_types: {
-              card: 25907032203,
-              bank_account: 108476658,
-              bitcoin_receiver: 1545182
-            }
-          }],
+          }
+        ],
         connect_reserved: [
           {
             currency: "usd",
             amount: 4700
-          }],
+          }
+        ],
         livemode: false,
         pending: [
           {
@@ -1050,22 +1041,23 @@ module StripeMock
               bank_account: 0,
               bitcoin_receiver: 6944
             }
-          }]
+          }
+        ]
       }
     end
 
-    def self.mock_balance_transactions(ids=[])
+    def self.mock_balance_transactions(ids = [])
       bts = {}
       ids.each do |id|
-        bts[id] = self.mock_balance_transaction(id: id)
+        bts[id] = mock_balance_transaction(id: id)
       end
       bts
     end
 
     def self.mock_balance_transaction(params = {})
       currency = params[:currency] || StripeMock.default_currency
-      bt_id = params[:id] || 'test_txn_default'
-      source = params[:source] || 'ch_test_charge'
+      bt_id = params[:id] || "test_txn_default"
+      source = params[:source] || "ch_test_charge"
       {
         id: bt_id,
         object: "balance_transaction",
@@ -1099,24 +1091,24 @@ module StripeMock
     end
 
     def self.mock_subscription_item(params = {})
-      id = params[:id] || 'test_txn_default'
+      iid = params[:id] || "test_txn_default"
       {
-        id: id,
-        object: 'subscription_item',
+        id: iid,
+        object: "subscription_item",
         created: 1504716183,
         metadata: {
-      },
+        },
         plan: {
-          id: 'PER_USER_PLAN1',
-          object: 'plan',
+          id: "PER_USER_PLAN1",
+          object: "plan",
           amount: 1337,
           created: 1504716177,
           currency: StripeMock.default_currency,
-          interval: 'month',
+          interval: "month",
           interval_count: 1,
           livemode: false,
           metadata: {},
-          name: 'StripeMock Default Plan ID',
+          name: "StripeMock Default Plan ID",
           statement_descriptor: nil,
           trial_period_days: nil
         },
@@ -1148,135 +1140,99 @@ module StripeMock
       amount = params[:amount] || 49900
       currency = params[:currency] || StripeMock.default_currency
       {
-          id: payment_intent_id,
-          object: "payment_intent",
-          amount: amount,
-          amount_capturable: 0,
-          amount_received: 0,
-          application: nil,
-          application_fee_amount: nil,
-          canceled_at: nil,
-          cancellation_reason: nil,
-          capture_method: "automatic",
-          charges: {
-              object: "list",
-              data: [],
-              has_more: false,
-              total_count: 1,
-              url: "/v1/charges?payment_intent=pi_1EwXFB2eZvKYlo2CggNnFBo8"
-          },
-          client_secret: "pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v",
-          confirmation_method: "manual",
-          created: 1563208901,
-          currency: currency,
-          customer: nil,
-          description: nil,
-          invoice: nil,
-          last_payment_error: nil,
-          livemode: false,
-          metadata: {},
-          next_action: { type: "use_stripe_sdk" },
-          on_behalf_of: nil,
-          payment_method: nil,
-          payment_method_types: [
-              "card"
-          ],
-          receipt_email: nil,
-          review: nil,
-          setup_future_usage: nil,
-          shipping: nil,
-          source: nil,
-          statement_descriptor: nil,
-          status: "requires_action",
-          transfer_data: nil,
-          transfer_group: nil
+        id: payment_intent_id,
+        object: "payment_intent",
+        amount: amount,
+        amount_capturable: 0,
+        amount_received: 0,
+        application: nil,
+        application_fee_amount: nil,
+        canceled_at: nil,
+        cancellation_reason: nil,
+        capture_method: "automatic",
+        charges: {
+          object: "list",
+          data: [],
+          has_more: false,
+          total_count: 1,
+          url: "/v1/charges?payment_intent=pi_1EwXFB2eZvKYlo2CggNnFBo8"
+        },
+        client_secret: "pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v",
+        confirmation_method: "manual",
+        created: 1563208901,
+        currency: currency,
+        customer: nil,
+        description: nil,
+        invoice: nil,
+        last_payment_error: nil,
+        livemode: false,
+        metadata: {},
+        next_action: {type: "use_stripe_sdk"},
+        on_behalf_of: nil,
+        payment_method: nil,
+        payment_method_types: [
+          "card"
+        ],
+        receipt_email: nil,
+        review: nil,
+        setup_future_usage: nil,
+        shipping: nil,
+        source: nil,
+        statement_descriptor: nil,
+        status: "requires_action",
+        transfer_data: nil,
+        transfer_group: nil
       }.merge(params)
     end
 
     def self.mock_payment_method(params = {})
-      payment_method_id = params[:id] || 'pm_1ExEuFL2DI6wht39WNJgbybl'
-
-      type = params[:type].to_sym
-      data = {
-        card: {
-          brand: 'visa',
-          checks: {
-            address_line1_check: nil,
-            address_postal_code_check: nil,
-            cvc_check: 'pass'
-          },
-          country: 'FR',
-          exp_month: 2,
-          exp_year: 2022,
-          fingerprint: 'Hr3Ly5z5IYxsokWA',
-          funding: 'credit',
-          generated_from: nil,
-          last4: '3155',
-          three_d_secure_usage: { supported: true },
-          wallet: nil
-        },
-        ideal: {
-          bank: 'ing',
-          bic: 'INGBNL2A',
-          iban_last4: '****',
-          verified_name: 'JENNY ROSEN'
-        },
-        sepa_debit: {
-          bank_code: '37040044',
-          branch_code: '',
-          country: 'DE',
-          fingerprint: 'FD81kbVPe7M05BMj',
-          last4: '3000'
-        }
-      }
-
+      payment_method_id = params[:id] || "pm_1ExEuFL2DI6wht39WNJgbybl"
       {
         id: payment_method_id,
-        object: 'payment_method',
-        type: params[:type],
-        billing_details: {
-          address: {
-            city: 'New Orleans',
-            country: 'US',
-            line1: 'Bourbon Street 23',
-            line2: nil,
-            postal_code: '10000',
-            state: nil
-          },
-          email: 'foo@bar.com',
-          name: 'John Dolton',
-          phone: nil
+        object: "payment_method",
+        type: "card",
+        billing_details: {},
+        card: {
+          brand: "visa",
+          checks: {address_line1_check: nil, address_postal_code_check: nil, cvc_check: "pass"},
+          country: "FR",
+          exp_month: 2,
+          exp_year: 2022,
+          fingerprint: "Hr3Ly5z5IYxsokWA",
+          funding: "credit",
+          last4: "3155",
+          three_d_secure_usage: {supported: true}
         },
         customer: params[:customer] || nil,
         metadata: {
-          order_id: '123456789'
+          order_id: "123456789"
         }
-      }.merge(type => data[type]).merge(params)
+      }.merge(params)
     end
 
     def self.mock_setup_intent(params = {})
       setup_intent_id = params[:id] || "seti_1F96eK2aLAadsDqo0AVIyPmC"
       {
-        :id => setup_intent_id,
-        :object => "setup_intent",
-        :application => nil,
-        :cancellation_reason => nil,
-        :client_secret => "seti_1F96eK2aLAadsDqo0AVIyPmC_secret_FePTYgOoPFxDOUL53fFMSoTAyiXsWAV",
-        :created => 1566204936,
-        :customer => nil,
-        :description => nil,
-        :last_setup_error => nil,
-        :livemode => false,
-        :metadata => {},
-        :next_action => nil,
-        :on_behalf_of => nil,
-        :payment_method => nil,
-        :payment_method_options => {
+        id: setup_intent_id,
+        object: "setup_intent",
+        application: nil,
+        cancellation_reason: nil,
+        client_secret: "seti_1F96eK2aLAadsDqo0AVIyPmC_secret_FePTYgOoPFxDOUL53fFMSoTAyiXsWAV",
+        created: 1566204936,
+        customer: nil,
+        description: nil,
+        last_setup_error: nil,
+        livemode: false,
+        metadata: {},
+        next_action: nil,
+        on_behalf_of: nil,
+        payment_method: nil,
+        payment_method_options: {
           card: {request_three_d_secure: "automatic"}
         },
-        :payment_method_types => ["card"],
-        :status => "requires_payment_method",
-        :usage => "off_session"
+        payment_method_types: ["card"],
+        status: "requires_payment_method",
+        usage: "off_session"
       }.merge(params)
     end
 
@@ -1285,9 +1241,9 @@ module StripeMock
       currency = params[:currency] || StripeMock.default_currency
       {
         id: cs_id,
-        object: 'checkout.session',
+        object: "checkout.session",
         billing_address_collection: nil,
-        cancel_url: 'https://example.com/cancel',
+        cancel_url: "https://example.com/cancel",
         client_reference_id: nil,
         customer: nil,
         customer_email: nil,
@@ -1296,12 +1252,12 @@ module StripeMock
             amount: 1500,
             currency: currency,
             custom: {
-              description: 'Comfortable cotton t-shirt',
+              description: "Comfortable cotton t-shirt",
               images: nil,
-              name: 'T-shirt'
+              name: "T-shirt"
             },
             quantity: 2,
-            type: 'custom'
+            type: "custom"
           }
         ],
         livemode: false,
@@ -1309,12 +1265,12 @@ module StripeMock
         mode: nil,
         payment_intent: mock_payment_intent[:id],
         payment_method_types: [
-          'card'
+          "card"
         ],
         setup_intent: nil,
         submit_type: nil,
         subscription: nil,
-        success_url: 'https://example.com/success'
+        success_url: "https://example.com/success"
       }.merge(params)
     end
   end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -1,23 +1,22 @@
 module StripeMock
   class Instance
-
     include StripeMock::RequestHandlers::Helpers
     include StripeMock::RequestHandlers::ParamValidators
 
-    DUMMY_API_KEY = (0...32).map { (65 + rand(26)).chr }.join.downcase
+    DUMMY_API_KEY = (0...32).map { rand(65..90).chr }.join.downcase
 
     # Handlers are ordered by priority
     @@handlers = []
 
     def self.add_handler(route, name)
       @@handlers << {
-        :route => %r{^#{route}$},
-        :name => name
+        route: %r{^#{route}$},
+        name: name
       }
     end
 
     def self.handler_for_method_url(method_url)
-      @@handlers.find {|h| method_url =~ h[:route] }
+      @@handlers.find { |h| method_url =~ h[:route] }
     end
 
     include StripeMock::RequestHandlers::PaymentIntents
@@ -54,16 +53,16 @@ module StripeMock
     include StripeMock::RequestHandlers::Checkout::Session
 
     attr_reader :accounts, :balance, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
-                :disputes, :events, :invoices, :invoice_items, :orders, :payment_intents, :payment_methods,
-                :setup_intents, :plans, :recipients, :refunds, :transfers, :payouts, :subscriptions, :country_spec,
-                :subscriptions_items, :products, :tax_rates, :checkout_sessions
+      :disputes, :events, :invoices, :invoice_items, :orders, :payment_intents, :payment_methods,
+      :setup_intents, :plans, :recipients, :refunds, :transfers, :payouts, :subscriptions, :country_spec,
+      :subscriptions_items, :products, :tax_rates, :checkout_sessions
 
     attr_accessor :error_queue, :debug, :conversion_rate, :account_balance
 
     def initialize
       @accounts = {}
       @balance = Data.mock_balance
-      @balance_transactions = Data.mock_balance_transactions(['txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI'])
+      @balance_transactions = Data.mock_balance_transactions(["txn_05RsQX2eZvKYlo2C0FRTGSSA", "txn_15RsQX2eZvKYlo2C0ERTYUIA", "txn_25RsQX2eZvKYlo2C0ZXCVBNM", "txn_35RsQX2eZvKYlo2C0QAZXSWE", "txn_45RsQX2eZvKYlo2C0EDCVFRT", "txn_55RsQX2eZvKYlo2C0OIKLJUY", "txn_65RsQX2eZvKYlo2C0ASDFGHJ", "txn_75RsQX2eZvKYlo2C0EDCXSWQ", "txn_85RsQX2eZvKYlo2C0UJMCDET", "txn_95RsQX2eZvKYlo2C0EDFRYUI"])
       @bank_tokens = {}
       @card_tokens = {}
       @customers = {}
@@ -72,7 +71,7 @@ module StripeMock
       @payment_methods = {}
       @setup_intents = {}
       @coupons = {}
-      @disputes = Data.mock_disputes(['dp_05RsQX2eZvKYlo2C0FRTGSSA','dp_15RsQX2eZvKYlo2C0ERTYUIA', 'dp_25RsQX2eZvKYlo2C0ZXCVBNM', 'dp_35RsQX2eZvKYlo2C0QAZXSWE', 'dp_45RsQX2eZvKYlo2C0EDCVFRT', 'dp_55RsQX2eZvKYlo2C0OIKLJUY', 'dp_65RsQX2eZvKYlo2C0ASDFGHJ', 'dp_75RsQX2eZvKYlo2C0EDCXSWQ', 'dp_85RsQX2eZvKYlo2C0UJMCDET', 'dp_95RsQX2eZvKYlo2C0EDFRYUI'])
+      @disputes = Data.mock_disputes(["dp_05RsQX2eZvKYlo2C0FRTGSSA", "dp_15RsQX2eZvKYlo2C0ERTYUIA", "dp_25RsQX2eZvKYlo2C0ZXCVBNM", "dp_35RsQX2eZvKYlo2C0QAZXSWE", "dp_45RsQX2eZvKYlo2C0EDCVFRT", "dp_55RsQX2eZvKYlo2C0OIKLJUY", "dp_65RsQX2eZvKYlo2C0ASDFGHJ", "dp_75RsQX2eZvKYlo2C0EDCXSWQ", "dp_85RsQX2eZvKYlo2C0UJMCDET", "dp_95RsQX2eZvKYlo2C0EDFRYUI"])
       @events = {}
       @invoices = {}
       @invoice_items = {}
@@ -123,7 +122,7 @@ module StripeMock
           @error_queue.dequeue
           raise mock_error
         else
-          res = self.send(handler[:name], handler[:route], method_url, params, headers)
+          res = send(handler[:name], handler[:route], method_url, params, headers)
           puts "           [res]  #{res}" if @debug == true
           [to_faraday_hash(res), api_key]
         end
@@ -135,8 +134,8 @@ module StripeMock
     end
 
     def generate_webhook_event(event_data)
-      event_data[:id] ||= new_id 'evt'
-      @events[ event_data[:id] ] = symbolize_names(event_data)
+      event_data[:id] ||= new_id "evt"
+      @events[event_data[:id]] = symbolize_names(event_data)
     end
 
     def upsert_stripe_object(object, attributes)
@@ -149,9 +148,9 @@ module StripeMock
         # Insert new Stripe object
         case object
           when :balance_transaction
-            id = new_balance_transaction('txn', attributes)
+            id = new_balance_transaction("txn", attributes)
           when :dispute
-            id = new_dispute('dp', attributes)
+            id = new_dispute("dp", attributes)
           else
             raise UnsupportedRequestError.new "Unsupported stripe object `#{object}`"
         end
@@ -173,7 +172,7 @@ module StripeMock
 
     private
 
-    def assert_existence(type, id, obj, message=nil)
+    def assert_existence(type, id, obj, message = nil)
       if obj.nil?
         msg = message || "No such #{type}: #{id}"
         raise Stripe::InvalidRequestError.new(msg, type.to_s, http_status: 404)


### PR DESCRIPTION
https://stripe.com/docs/api/charges/object

I needed this for the https://github.com/pay-rails/pay used in jumpstartrails/jumpstartpro