### PR TITLE
[Data] Add receipt_url to charge and refund mock data

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -184,6 +184,7 @@ module StripeMock
         fraud_details: {},
         receipt_email: nil,
         receipt_number: nil,
+        receipt_url: nil,
         refunded: false,
         shipping: {},
         statement_descriptor: "Charge #{charge_id}",
@@ -244,7 +245,8 @@ module StripeMock
         charge: "ch_4fWhYjzQ23UFWT",
         receipt_number: nil,
         status: "succeeded",
-        reason: "requested_by_customer"
+        reason: "requested_by_customer",
+        receipt_url: nil
       }.merge(params)
     end
 


### PR DESCRIPTION
`Stripe::Charge.create` and `Stripe::Refund.create` will throw
`NoMethodError: undefined method `receipt_url'`.

Add `receipt_url` to charge and refund mock data to fix this error