### PR TITLE
Adding express dashboard login link mock

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -48,6 +48,7 @@ require 'stripe_mock/request_handlers/helpers/token_helpers.rb'
 require 'stripe_mock/request_handlers/validators/param_validators.rb'
 
 require 'stripe_mock/request_handlers/account_links.rb'
+require 'stripe_mock/request_handlers/express_login_links.rb'
 require 'stripe_mock/request_handlers/accounts.rb'
 require 'stripe_mock/request_handlers/external_accounts.rb'
 require 'stripe_mock/request_handlers/balance.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -112,6 +112,16 @@ module StripeMock
       }.merge(params)
     end
 
+    def self.mock_express_login_link(params = {})
+      now = Time.now.to_i
+      {
+        object: 'login_link',
+        created: now,
+        url: 'https://connect.stripe.com/express/Ln7FfnNpUcCU',
+        data: {}
+      }.merge(params)
+    end
+
     def self.mock_tax_rate(params)
       {
         id: 'test_cus_default',

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -25,6 +25,7 @@ module StripeMock
     include StripeMock::RequestHandlers::SetupIntents
     include StripeMock::RequestHandlers::ExternalAccounts
     include StripeMock::RequestHandlers::AccountLinks
+    include StripeMock::RequestHandlers::ExpressLoginLinks
     include StripeMock::RequestHandlers::Accounts
     include StripeMock::RequestHandlers::Balance
     include StripeMock::RequestHandlers::BalanceTransactions

--- a/lib/stripe_mock/request_handlers/express_login_links.rb
+++ b/lib/stripe_mock/request_handlers/express_login_links.rb
@@ -1,0 +1,15 @@
+module StripeMock
+  module RequestHandlers
+    module ExpressLoginLinks
+
+      def ExpressLoginLinks.included(klass)
+        klass.add_handler 'post /v1/accounts/(.*)/login_links', :new_account_login_link
+      end
+
+      def new_account_login_link(route, method_url, params, headers)
+        route =~ method_url
+        Data.mock_express_login_link(params)
+      end
+    end
+  end
+end

--- a/spec/shared_stripe_examples/express_login_link_examples.rb
+++ b/spec/shared_stripe_examples/express_login_link_examples.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+shared_examples 'Express Login Link API' do
+  describe 'create an Express Login Link' do
+    it 'creates a login link' do
+      account_link = Stripe::Account.create_login_link('acct_103ED82ePvKYlo2C')
+
+      expect(account_link).to be_a Stripe::LoginLink
+      expect(account_link.url).to start_with('https://connect.stripe.com/express/')
+    end
+  end
+end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -13,6 +13,7 @@ def it_behaves_like_stripe(&block)
   it_behaves_like 'Card API', &block
   it_behaves_like 'Charge API', &block
   it_behaves_like 'Bank API', &block
+  it_behaves_like 'Express Login Link API', &block
   it_behaves_like 'External Account API', &block
   it_behaves_like 'Coupon API', &block
   it_behaves_like 'Customer API', &block


### PR DESCRIPTION
Adds mock for [Express Login Link API](https://stripe.com/docs/api/account/login_link). Adds a single `POST` endpoint to `/v1/accounts/(.*)/login_links`