### PR TITLE
Include payment_method in PaymentIntent charges

### DIFF
--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -176,7 +176,8 @@ module StripeMock
         payment_intent[:charges][:data] << Data.mock_charge(
           balance_transaction: btxn,
           amount: payment_intent[:amount],
-          currency: payment_intent[:currency]
+          currency: payment_intent[:currency],
+          payment_method: payment_intent[:payment_method]
         )
 
         payment_intent

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -92,6 +92,16 @@ shared_examples 'PaymentIntent API' do
     expect(Stripe::BalanceTransaction.retrieve(balance_txn).id).to eq(balance_txn)
   end
 
+  it "includes the payment_method on charges" do
+    payment_intent = Stripe::PaymentIntent.create(
+      amount: 100, currency: "usd", confirm: true, payment_method: "test_pm_1"
+    )
+    expect(payment_intent.status).to eq("succeeded")
+    expect(payment_intent.charges.data.size).to eq(1)
+    expect(payment_intent.charges.data.first.object).to eq("charge")
+    expect(payment_intent.charges.data.first.payment_method).to eq("test_pm_1")
+  end
+
   it "confirms a stripe payment_intent" do
     payment_intent = Stripe::PaymentIntent.create(amount: 100, currency: "usd")
     confirmed_payment_intent = payment_intent.confirm()


### PR DESCRIPTION
A Payment Intent captured with a payment method should reflect the payment method in any charges created against it to match the behaviour of real Stripe.