### PR TITLE
Update expanding args to be ruby-3.0 compatible.

### DIFF
--- a/lib/stripe_mock/api/client.rb
+++ b/lib/stripe_mock/api/client.rb
@@ -8,7 +8,9 @@ module StripeMock
     return false if @state == 'live'
     return @client unless @client.nil?
 
-    Stripe::StripeClient.send(:define_method, :execute_request) { |*args| StripeMock.redirect_to_mock_server(*args) }
+    Stripe::StripeClient.send(:define_method, :execute_request) do |*args|
+      StripeMock.redirect_to_mock_server(args[0], args[1], **args[2])
+    end
     @client = StripeMock::Client.new(port)
     @state = 'remote'
     @client

--- a/lib/stripe_mock/api/instance.rb
+++ b/lib/stripe_mock/api/instance.rb
@@ -7,7 +7,9 @@ module StripeMock
   def self.start
     return false if @state == 'live'
     @instance = instance = Instance.new
-    Stripe::StripeClient.send(:define_method, :execute_request) { |*args| instance.mock_request(*args) }
+    Stripe::StripeClient.send(:define_method, :execute_request) do |*args|
+      instance.mock_request(args[0], args[1], **args[2])
+    end
     @state = 'local'
   end
 


### PR DESCRIPTION
Ruby 3.0 changes the acceptable style of expanding args into a method call as outlined here:

https://rubyreferences.github.io/rubychanges/3.0.html#language-changes

This PR fixes a key location where this is called to mock requests.