### PR TITLE
Support Stripe Connect by adding stripe_account header namespace for customers

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -67,7 +67,7 @@ module StripeMock
       @balance_transactions = Data.mock_balance_transactions(['txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI'])
       @bank_tokens = {}
       @card_tokens = {}
-      @customers = {}
+      @customers = { Stripe.api_key => {} }
       @charges = {}
       @payment_intents = {}
       @payment_methods = {}

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -57,12 +57,13 @@ module StripeMock
       end
 
       def upcoming_invoice(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
         raise Stripe::InvalidRequestError.new('Missing required param: customer', nil, http_status: 400) if params[:customer].nil?
         raise Stripe::InvalidRequestError.new('When previewing changes to a subscription, you must specify either `subscription` or `subscription_items`', nil, http_status: 400) if !params[:subscription_proration_date].nil? && params[:subscription].nil? && params[:subscription_plan].nil?
         raise Stripe::InvalidRequestError.new('Cannot specify proration date without specifying a subscription', nil, http_status: 400) if !params[:subscription_proration_date].nil? && params[:subscription].nil?
 
-        customer = customers[params[:customer]]
+        customer = customers[stripe_account][params[:customer]]
         assert_existence :customer, params[:customer], customer
 
         raise Stripe::InvalidRequestError.new("No upcoming invoices for customer: #{customer[:id]}", nil, http_status: 404) if customer[:subscriptions][:data].length == 0

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -51,14 +51,15 @@ module StripeMock
 
         Data.mock_list_object(clone.values, params)
       end
-      
+
       # post /v1/payment_methods/:id/attach
       def attach_payment_method(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         allowed_params = [:customer]
 
         id = method_url.match(route)[1]
 
-        assert_existence :customer, params[:customer], customers[params[:customer]]
+        assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
 
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -12,30 +12,35 @@ module StripeMock
       end
 
       def create_source(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        add_source_to(:customer, $1, params, customers)
+        add_source_to(:customer, $1, params, customers[stripe_account])
       end
 
       def retrieve_sources(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        retrieve_object_cards(:customer, $1, customers)
+        retrieve_object_cards(:customer, $1, customers[stripe_account])
       end
 
       def retrieve_source(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        customer = assert_existence :customer, $1, customers[$1]
+        customer = assert_existence :customer, $1, customers[stripe_account][$1]
 
         assert_existence :card, $2, get_card(customer, $2)
       end
 
       def delete_source(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        delete_card_from(:customer, $1, $2, customers)
+        delete_card_from(:customer, $1, $2, customers[stripe_account])
       end
 
       def update_source(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        customer = assert_existence :customer, $1, customers[$1]
+        customer = assert_existence :customer, $1, customers[stripe_account][$1]
 
         card = assert_existence :card, $2, get_card(customer, $2)
         card.merge!(params)
@@ -43,8 +48,9 @@ module StripeMock
       end
 
       def verify_source(route, method_url, params, headers)
+        stripe_account = headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        customer = assert_existence :customer, $1, customers[$1]
+        customer = assert_existence :customer, $1, customers[stripe_account][$1]
 
         bank_account = assert_existence :bank_account, $2, verify_bank_account(customer, $2)
         bank_account


### PR DESCRIPTION
The Stripe library allows us to use pretty much every API call with an optional `stripe_account` key/value pair that is the Stripe user ID of the connected account.  For example:

```ruby
Stripe::Customer.update(connected_customer.id, { some: 'hash with customer data' }, stripe_account: 'some_stripe_user_id_string' )
```

The current implementation of this mocking library does not correctly mock this API. It will always use the default Stripe API key, when it should determine which API key to use based on the `stripe_account` key.

Any data relative to that account should be namespaced accordingly for future retrieval later when using the same `stripe_account` data. 

For example, if you are creating a customer using  `stripe_account: customer_1_stripe_id`, then this customer should not appear in a `Customer.list` call using `strip_account: customer_2_stripe_id`.

This PR accomplishes this by namespacing the mock requests and data based on the `stripe_account` key...and if it's not provided, we default back to the app's Stripe API key.