### PR TITLE
Properly set the status of a trialing subscription

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -203,6 +203,10 @@ module StripeMock
           end
         end
 
+        if params[:trial_period_days]
+          subscription[:status] = 'trialing'
+        end
+
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
           subscription[:canceled_at] = Time.now.utc.to_i

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -137,6 +137,10 @@ module StripeMock
           end
         end
 
+        if params[:trial_period_days]
+          subscription[:status] = 'trialing'
+        end
+
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
           subscription[:canceled_at] = Time.now.utc.to_i


### PR DESCRIPTION
The Stripe API will make a subscription as `trialing` if the parameter for `trial_period_days` is set.

This PR adds that logic when updating and creating subscriptions.