### PR TITLE
Add status for charge.succeeded event

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
@@ -49,7 +49,8 @@
       "description": null,
       "dispute": null,
       "metadata": {
-      }
+      },
+      "status": "succeeded"
     }
   }
 }


### PR DESCRIPTION
I am working with webhooks and find that `charge.succeeded` event doesn't has a status field. But `charge.faild` event has this field. Please add default this status for  `charge.succeeded`.