### PR TITLE
Type is not required when cloning a PaymentMethod

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1235,7 +1235,6 @@ module StripeMock
     def self.mock_payment_method(params = {})
       payment_method_id = params[:id] || 'pm_1ExEuFL2DI6wht39WNJgbybl'
 
-      type = params[:type].to_sym
       data = {
         card: {
           brand: 'visa',
@@ -1268,6 +1267,7 @@ module StripeMock
           last4: '3000'
         }
       }
+      type_param = data.select { |k,v| k == (params[:type] || '').to_sym }
 
       {
         id: payment_method_id,
@@ -1290,7 +1290,7 @@ module StripeMock
         metadata: {
           order_id: '123456789'
         }
-      }.merge(type => data[type]).deep_merge(params)
+      }.merge(type_param).deep_merge(params)
     end
 
     def self.mock_setup_intent(params = {})

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1290,7 +1290,7 @@ module StripeMock
         metadata: {
           order_id: '123456789'
         }
-      }.merge(type => data[type]).merge(params)
+      }.merge(type => data[type]).deep_merge(params)
     end
 
     def self.mock_setup_intent(params = {})

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -101,6 +101,8 @@ module StripeMock
       private
 
       def ensure_payment_method_required_params(params)
+        return if params[:payment_method]
+
         require_param(:type) if params[:type].nil?
 
         if invalid_type?(params[:type])

--- a/spec/shared_stripe_examples/payment_method_examples.rb
+++ b/spec/shared_stripe_examples/payment_method_examples.rb
@@ -128,6 +128,17 @@ shared_examples 'PaymentMethod API' do
         expect { payment_method }.to raise_error(Stripe::InvalidRequestError)
       end
     end
+
+    context 'when a payment_method is supplied' do
+      let(:type) { nil }
+      let(:original) { Stripe::PaymentMethod.create(type: 'card') }
+      let(:payment_method) { Stripe::PaymentMethod.create(payment_method: original.id, type: type) }
+
+      it 'allows cloning a payment method without specifying the type' do
+        expect(payment_method.id).to match(/^test_pm/)
+        expect(payment_method.id).not_to eq(original.id)
+      end
+    end
   end
 
   # get /v1/payment_methods/:id


### PR DESCRIPTION
When cloning a PaymentMethod, the type parameter is [not required when `payment_method` is specified](https://stripe.com/docs/api/payment_methods/create#create_payment_method-type)