### PR TITLE
Allows filtering prices by currency and product

### DIFF
--- a/lib/stripe_mock/request_handlers/prices.rb
+++ b/lib/stripe_mock/request_handlers/prices.rb
@@ -37,6 +37,18 @@ module StripeMock
           end
         end
 
+        if params.key?(:currency)
+          price_data.select! do |price|
+            params[:currency] == price[:currency]
+          end
+        end
+
+        if params.key?(:product)
+          price_data.select! do |price|
+            params[:product] == price[:product]
+          end
+        end
+
         Data.mock_list_object(price_data.first(limit), params.merge!(limit: limit))
       end
     end


### PR DESCRIPTION
This commit implements the `currency` and `product` filters
in the prices list, since they are supported by the Stripe API.

See https://stripe.com/docs/api/prices/list