### PR TITLE
Pass `*kwargs` through to `mock_request` in `StripeMock::Server`

### DIFF
--- a/lib/stripe_mock/server.rb
+++ b/lib/stripe_mock/server.rb
@@ -16,9 +16,9 @@ module StripeMock
       self.clear_data
     end
 
-    def mock_request(*args)
+    def mock_request(*args, **kwargs)
       begin
-        @instance.mock_request(*args)
+        @instance.mock_request(*args, **kwargs)
       rescue Stripe::InvalidRequestError => e
         {
           :error_raised => 'invalid_request',


### PR DESCRIPTION
This fixes an error where using the `StripeMock::Server` failed with an `ArgumentError`.