### PR TITLE
Stop requiring `type` to be set for `Stripe::Product`

### DIFF
--- a/lib/stripe_mock/request_handlers/validators/param_validators.rb
+++ b/lib/stripe_mock/request_handlers/validators/param_validators.rb
@@ -29,10 +29,6 @@ module StripeMock
           raise Stripe::InvalidRequestError.new(missing_param_message(k), k) if params[k].nil?
         end
 
-        if !%w[good service].include?(params[:type])
-          raise Stripe::InvalidRequestError.new("Invalid type: must be one of good or service", :type)
-        end
-
         if products[ params[:id] ]
           raise Stripe::InvalidRequestError.new(already_exists_message(Stripe::Product), :id)
         end

--- a/spec/shared_stripe_examples/product_examples.rb
+++ b/spec/shared_stripe_examples/product_examples.rb
@@ -101,14 +101,6 @@ shared_examples "Product API" do
       it("requires a name") { @attribute_name = :name }
     end
 
-    describe "Inclusion" do
-      it "validates inclusion of type in 'good' or 'service'" do
-        expect {
-          Stripe::Product.create(params.merge({type: "OOPS"}))
-        }.to raise_error(Stripe::InvalidRequestError, "Invalid type: must be one of good or service")
-      end
-    end
-
     describe "Uniqueness" do
       let(:already_exists_message){ stripe_validator.already_exists_message(Stripe::Product) }
 


### PR DESCRIPTION
It has been deprecated, so no longer needs to be set https://discord.com/channels/841573134531821608/841573134531821616/864551199407996949