### PR TITLE
Fail with Stripe::InvalidRequestError instead of undefined method '[]' for nil:NilClass

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -61,7 +61,7 @@ module StripeMock
       def update_customer(route, method_url, params, headers)
         stripe_account = headers && headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        cus = assert_existence :customer, $1, customers[stripe_account][$1]
+        cus = assert_existence :customer, $1, customers.dig(stripe_account, $1)
 
         # get existing and pending metadata
         metadata = cus.delete(:metadata) || {}
@@ -112,10 +112,10 @@ module StripeMock
       def delete_customer(route, method_url, params, headers)
         stripe_account = headers && headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        assert_existence :customer, $1, customers[stripe_account][$1]
+        assert_existence :customer, $1, customers.dig(stripe_account, $1)
 
         customers[stripe_account][$1] = {
-          id: customers[stripe_account][$1][:id],
+          id: customers.dig(stripe_account, $1)[:id],
           deleted: true
         }
       end
@@ -123,7 +123,7 @@ module StripeMock
       def get_customer(route, method_url, params, headers)
         stripe_account = headers && headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        customer = assert_existence :customer, $1, customers[stripe_account][$1]
+        customer = assert_existence :customer, $1, customers.dig(stripe_account, $1)
 
         customer = customer.clone
         if params[:expand] == ['default_source'] && customer[:sources][:data]
@@ -143,7 +143,7 @@ module StripeMock
       def delete_customer_discount(route, method_url, params, headers)
         stripe_account = headers && headers[:stripe_account] || Stripe.api_key
         route =~ method_url
-        cus = assert_existence :customer, $1, customers[stripe_account][$1]
+        cus = assert_existence :customer, $1, customers.dig(stripe_account, $1)
 
         cus[:discount] = nil
 

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -55,7 +55,6 @@ module StripeMock
         bank_account = assert_existence :bank_account, $2, verify_bank_account(customer, $2)
         bank_account
       end
-
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -17,13 +17,13 @@ module StripeMock
         cus_id = params[:customer]
 
         if cus_id && params[:source]
-          customer = assert_existence :customer, cus_id, customers[stripe_account][cus_id]
+          customer = assert_existence :customer, cus_id, customers.dig(stripe_account, cus_id) || customers[Stripe.api_key][cus_id]
 
           # params[:card] is an id; grab it from the db
           customer_card = get_card(customer, params[:source])
           assert_existence :card, params[:source], customer_card
         elsif params[:card].is_a?(String)
-          customer = assert_existence :customer, cus_id, customers[stripe_account][cus_id]
+          customer = assert_existence :customer, cus_id, customers.dig(stripe_account, cus_id) || customers[Stripe.api_key][cus_id]
 
           # params[:card] is an id; grab it from the db
           customer_card = get_card(customer, params[:card])
@@ -34,7 +34,7 @@ module StripeMock
           params[:card][:last4] = params[:card][:number][-4,4]
           customer_card = params[:card]
         elsif params[:bank_account].is_a?(String)
-          customer = assert_existence :customer, cus_id, customers[stripe_account][cus_id]
+          customer = assert_existence :customer, cus_id, customers.dig(stripe_account, cus_id) || customers[Stripe.api_key][cus_id]
 
           # params[:bank_account] is an id; grab it from the db
           bank_account = verify_bank_account(customer, params[:bank_account])
@@ -43,7 +43,7 @@ module StripeMock
           # params[:card] is a hash of cc info; "Sanitize" the card number
           bank_account = params[:bank_account]
         else
-          customer = assert_existence :customer, cus_id, customers[stripe_account][cus_id] || customers[Stripe.api_key][cus_id]
+          customer = assert_existence :customer, cus_id, customers.dig(stripe_account, cus_id) || customers[Stripe.api_key][cus_id]
           customer_card = get_card(customer, customer[:default_source])
         end
 


### PR DESCRIPTION
With the new change in #762 of namespacing
stripe accounts, now the code fails differently
if the stripe account namespace is not set