### PR TITLE
Fixes `undefined method 'require_params'` when creating checkout session

### DIFF
--- a/lib/stripe_mock/request_handlers/checkout_session.rb
+++ b/lib/stripe_mock/request_handlers/checkout_session.rb
@@ -56,7 +56,7 @@ module StripeMock
           case params[:mode]
           when nil, "payment"
             params[:customer] ||= new_customer(nil, nil, {email: params[:customer_email]}, nil)[:id]
-            require_params(:line_items) if params[:line_items].nil? || params[:line_items].empty?
+            require_param(:line_items) if params[:line_items].nil? || params[:line_items].empty?
             payment_intent = new_payment_intent(nil, nil, {
               amount: amount,
               currency: currency,
@@ -77,7 +77,7 @@ module StripeMock
             payment_status = "no_payment_required"
           when "subscription"
             params[:customer] ||= new_customer(nil, nil, {email: params[:customer_email]}, nil)[:id]
-            require_params(:line_items) if params[:line_items].nil? || params[:line_items].empty?
+            require_param(:line_items) if params[:line_items].nil? || params[:line_items].empty?
             checkout_session_line_items[id] = line_items
           else
             throw Stripe::InvalidRequestError.new("Invalid mode: must be one of payment, setup, or subscription", :mode, http_status: 400)

--- a/spec/shared_stripe_examples/checkout_session_examples.rb
+++ b/spec/shared_stripe_examples/checkout_session_examples.rb
@@ -22,6 +22,20 @@ shared_examples "Checkout Session API" do
     expect(payment_intent.customer).to eq(session.customer)
   end
 
+  context "when creating a payment" do
+    it "requires line_items" do
+      expect do
+        session = Stripe::Checkout::Session.create(
+          customer: "customer_id",
+          success_url: "localhost/nada",
+          cancel_url: "localhost/nada",
+          payment_method_types: ["card"],
+        )
+      end.to raise_error(Stripe::InvalidRequestError, /line_items/i)
+
+    end
+  end
+
   it "creates SetupIntent with setup mode" do
     session = Stripe::Checkout::Session.create(
       mode: "setup",
@@ -33,6 +47,21 @@ shared_examples "Checkout Session API" do
     expect(session.setup_intent).to_not be_empty
     setup_intent = Stripe::SetupIntent.retrieve(session.setup_intent)
     expect(setup_intent.payment_method_types).to eq(["card"])
+  end
+
+  context "when creating a subscription" do
+    it "requires line_items" do
+      expect do
+        session = Stripe::Checkout::Session.create(
+          customer: "customer_id",
+          success_url: "localhost/nada",
+          cancel_url: "localhost/nada",
+          payment_method_types: ["card"],
+          mode: "subscription",
+        )
+      end.to raise_error(Stripe::InvalidRequestError, /line_items/i)
+
+    end
   end
 
   context "retrieve a checkout session" do


### PR DESCRIPTION
This PR addresses an issue where `require_params` was being called instead of `require_param`.  

Previously, when the aforementioned lines were run, an `undefined method` error was thrown.