### PR TITLE
Fix upcoming invoice failing when there was no customer

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -63,7 +63,8 @@ module StripeMock
         raise Stripe::InvalidRequestError.new('When previewing changes to a subscription, you must specify either `subscription` or `subscription_items`', nil, http_status: 400) if !params[:subscription_proration_date].nil? && params[:subscription].nil? && params[:subscription_plan].nil?
         raise Stripe::InvalidRequestError.new('Cannot specify proration date without specifying a subscription', nil, http_status: 400) if !params[:subscription_proration_date].nil? && params[:subscription].nil?
 
-        customer = customers[stripe_account][params[:customer]]
+        customer_id = params[:customer] || subscriptions[params[:subscription]][:customer]
+        customer = customers[stripe_account][customer_id]
         assert_existence :customer, params[:customer], customer
 
         raise Stripe::InvalidRequestError.new("No upcoming invoices for customer: #{customer[:id]}", nil, http_status: 404) if customer[:subscriptions][:data].length == 0


### PR DESCRIPTION
There's an issue where if we try to retrieve an invoice with just a subscription an error is raised saying that the customer needs to be present. So `Stripe::Invoice.upcoming(subscription: 'sub_123')` works with the Stripe API but not in the tests.

This PR fixes that issue by using the subscription's customer as a fallback.