### PR TITLE
Allow events to be filtered by created

### DIFF
--- a/lib/stripe_mock/request_handlers/events.rb
+++ b/lib/stripe_mock/request_handlers/events.rb
@@ -4,7 +4,7 @@ module StripeMock
 
       def Events.included(klass)
         klass.add_handler 'get /v1/events/(.*)', :retrieve_event
-        klass.add_handler 'get /v1/events',      :list_events 
+        klass.add_handler 'get /v1/events',      :list_events
       end
 
       def retrieve_event(route, method_url, params, headers)
@@ -13,9 +13,36 @@ module StripeMock
       end
 
       def list_events(route, method_url, params, headers)
-        Data.mock_list_object(events.values, params)
+        values = filter_by_created(events.values, params: params)
+        Data.mock_list_object(values, params)
       end
-      
+
+      private
+
+      def filter_by_created(event_list, params:)
+        if params[:created].nil?
+          return event_list
+        end
+
+        if params[:created].is_a?(Hash)
+          if params[:created][:gt]
+            event_list.select! { |event| event[:created] > params[:created][:gt].to_i }
+          end
+          if params[:created][:gte]
+            event_list.select! { |event| event[:created] >= params[:created][:gte].to_i }
+          end
+          if params[:created][:lt]
+            event_list.select! { |event| event[:created] < params[:created][:lt].to_i }
+          end
+          if params[:created][:lte]
+            event_list.select! { |event| event[:created] <= params[:created][:lte].to_i }
+          end
+        else
+          event_list.select! { |event| event[:created] == params[:created].to_i }
+        end
+        event_list
+      end
+
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/events.rb
+++ b/lib/stripe_mock/request_handlers/events.rb
@@ -26,19 +26,19 @@ module StripeMock
 
         if params[:created].is_a?(Hash)
           if params[:created][:gt]
-            event_list.select! { |event| event[:created] > params[:created][:gt].to_i }
+            event_list = event_list.select { |event| event[:created] > params[:created][:gt].to_i }
           end
           if params[:created][:gte]
-            event_list.select! { |event| event[:created] >= params[:created][:gte].to_i }
+            event_list = event_list.select { |event| event[:created] >= params[:created][:gte].to_i }
           end
           if params[:created][:lt]
-            event_list.select! { |event| event[:created] < params[:created][:lt].to_i }
+            event_list = event_list.select { |event| event[:created] < params[:created][:lt].to_i }
           end
           if params[:created][:lte]
-            event_list.select! { |event| event[:created] <= params[:created][:lte].to_i }
+            event_list = event_list.select { |event| event[:created] <= params[:created][:lte].to_i }
           end
         else
-          event_list.select! { |event| event[:created] == params[:created].to_i }
+          event_list = event_list.select { |event| event[:created] == params[:created].to_i }
         end
         event_list
       end


### PR DESCRIPTION
See https://stripe.com/docs/api/events/list#list_events-created for API documentation.

Let me know if the tests seem like they might be flaky, I can add Timecop to mock the times to ensure they line up. I think they should be OK as-is though.