### PR TITLE
Set the status to "incomplete" when Stripe::Subscription's payment_behavior is "default_incomplete".

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -132,6 +132,10 @@ module StripeMock
           subscription[:status] = 'trialing'
         end
 
+        if params[:payment_behavior] == 'default_incomplete'
+          subscription[:status] = 'incomplete'
+        end
+
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
           subscription[:canceled_at] = Time.now.utc.to_i
@@ -294,6 +298,7 @@ module StripeMock
         return if customer[:invoice_settings][:default_payment_method]
         return if customer[:trial_end]
         return if params[:trial_end]
+        return if params[:payment_behavior] == 'default_incomplete'
         return if subscription[:default_payment_method]
 
         plan_trial_period_days = plan[:trial_period_days] || 0

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -290,6 +290,18 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(customer.subscriptions.count).to eq(0)
     end
 
+    it "creates a subscription when subscription's payment_behavior is default_incomplete" do
+      plan = stripe_helper.create_plan(id: 'enterprise', product: product.id, amount: 499)
+      customer = Stripe::Customer.create(id: 'cardless')
+
+      sub = Stripe::Subscription.create({ plan: plan.id, customer: customer.id, payment_behavior: 'default_incomplete' })
+      customer = Stripe::Customer.retrieve('cardless')
+
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.status).to eq('incomplete')
+    end
+
     it "throws an error when subscribing a customer with no card" do
       plan = stripe_helper.create_plan(id: 'enterprise', product: product.id, amount: 499)
       customer = Stripe::Customer.create(id: 'cardless')


### PR DESCRIPTION
I tried to create a subscription which is payment_behavoir is deufalt_impcomplete, but ``StripeMock::RequestHandlers::Subscriptions::verify_card_present`` block my request.

I added "incomplete" status to subscirption when "default_incomplete" is passed.


@see https://stripe.com/docs/billing/subscriptions/build-subscription?ui=elements#create-subscription
You will find instructions on how to create a subscription without specifying a payment method.
In this doc, the payment and billing is finalized at the FrontEnd, and the "incomplete" subscription is created server-side first.

@see https://stripe.com/docs/api/subscriptions/create#create_subscription-payment_behavior

> Use default_incomplete to create Subscriptions with status=incomplete when the first invoice requires payment, otherwise start as active.