### PR TITLE
Create SetupIntent with another status if payment method is provided

### DIFF
--- a/lib/stripe_mock/request_handlers/setup_intents.rb
+++ b/lib/stripe_mock/request_handlers/setup_intents.rb
@@ -25,10 +25,12 @@ module StripeMock
 
       def new_setup_intent(route, method_url, params, headers)
         id = new_id('si')
+        status = params[:payment_method] ? 'requires_action' : 'requires_payment_method'
 
         setup_intents[id] = Data.mock_setup_intent(
           params.merge(
-            id: id
+            id: id,
+            status: status
           )
         )
 

--- a/spec/shared_stripe_examples/setup_intent_examples.rb
+++ b/spec/shared_stripe_examples/setup_intent_examples.rb
@@ -10,6 +10,14 @@ shared_examples 'SetupIntent API' do
     expect(setup_intent.status).to eq('requires_payment_method')
   end
 
+  it 'creates a stripe setup intent with payment method' do
+    setup_intent = Stripe::SetupIntent.create(payment_method: 'random')
+
+    expect(setup_intent.id).to match(/^test_si/)
+    expect(setup_intent.metadata.to_hash).to eq({})
+    expect(setup_intent.status).to eq('requires_action')
+  end
+
   describe "listing setup_intent" do
     before do
       3.times do


### PR DESCRIPTION
I had to check if there's `payment_method` provided to SetupIntent creation, however I figured out that it always has `requires_payment_method` status. Changed it a bit to have `requires_action` status if `payment_method` is provided