### PR TITLE
fix: use start_with? instead of starts_with?

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -147,7 +147,7 @@ module StripeMock
           subscription[:transfer_data][:amount_percent] ||= 100
         end
 
-        if (s = params[:expand]&.find { |s| s.starts_with? 'latest_invoice' })
+        if (s = params[:expand]&.find { |s| s.start_with? 'latest_invoice' })
           payment_intent = nil
           unless subscription[:status] == 'trialing'
             intent_status = subscription[:status] == 'incomplete' ? 'requires_payment_method' : 'succeeded'


### PR DESCRIPTION
The wrong method name was being used causing the tests to not pass, this PR fixes it.

[Ruby doc reference](https://apidock.com/ruby/String/start_with%3F)