### PR TITLE
fix: correct return of subscription items

### DIFF
--- a/lib/stripe_mock/request_handlers/subscription_items.rb
+++ b/lib/stripe_mock/request_handlers/subscription_items.rb
@@ -13,7 +13,7 @@ module StripeMock
 
         require_param(:subscription) unless params[:subscription]
 
-        Data.mock_list_object(subscriptions_items, params)
+        Data.mock_list_object(subscriptions_items.values, params)
       end
 
       def create_subscription_items(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/subscription_items_examples.rb
+++ b/spec/shared_stripe_examples/subscription_items_examples.rb
@@ -64,6 +64,8 @@ shared_examples 'Subscription Items API' do
       all = Stripe::SubscriptionItem.list(subscription: subscription.id)
 
       expect(all.count).to eq(2)
+      expect(all.data[0]).to be_a(Stripe::SubscriptionItem)
+      expect(all.data[1]).to be_a(Stripe::SubscriptionItem)
     end
     it 'when no subscription param' do
       expect { Stripe::SubscriptionItem.list }.to raise_error { |e|


### PR DESCRIPTION
Original PR: #811 . Accidentally closed

## Description

Currently, the whole hash is passed to `mock_list_object` instead of only the values. This generates an incorrect response.

### Example
With:
```ruby
Stripe::SubscriptionItem.create(plan: plan.id, subscription: subscription.id, quantity: 2)
Stripe::SubscriptionItem.create(plan: plan2.id, subscription: subscription.id, quantity: 20)
```
Then:
```ruby
Stripe::SubscriptionItem.list(subscription: subscription.id)
```

Returns:
```ruby
=> #<Stripe::ListObject:0x1e00> JSON: {
  "object": "list",
  "data": [
    [
      "test_si_7",
      {"id":"test_si_7","object":"subscription_item","created":1504716183,"metadata":{},"plan":{"id":"silver_plan","object":"plan","active":true,"aggregate_usage":null,"amount":1337,"billing_scheme":"per_unit","created":1466698898,"currency":"usd","interval":"month","interval_count":1,"livemode":false,"metadata":{},"nickname":"My Mock Plan","product":"stripe_mock_default_product_id","tiers":null,"tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"quantity":2,"subscription":"test_su_4"}
    ],
    [
      "test_si_8",
      {"id":"test_si_8","object":"subscription_item","created":1504716183,"metadata":{},"plan":{"id":"one_more_1_plan","object":"plan","active":true,"aggregate_usage":null,"amount":100,"billing_scheme":"per_unit","created":1466698898,"currency":"usd","interval":"month","interval_count":1,"livemode":false,"metadata":{},"nickname":"My Mock Plan","product":"stripe_mock_default_product_id","tiers":null,"tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"quantity":20,"subscription":"test_su_4"}
    ]
  ],
  "url": "/v1/arrays",
  "has_more": false
}
```

But should return:
```ruby
=> #<Stripe::ListObject:0x1e00> JSON: {
  "object": "list",
  "data": [
    {"id":"test_si_8","object":"subscription_item","created":1504716183,"metadata":{},"plan":{"id":"one_more_1_plan","object":"plan","active":true,"aggregate_usage":null,"amount":100,"billing_scheme":"per_unit","created":1466698898,"currency":"usd","interval":"month","interval_count":1,"livemode":false,"metadata":{},"nickname":"My Mock Plan","product":"stripe_mock_default_product_id","tiers":null,"tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"quantity":20,"subscription":"test_su_4"},
    {"id":"test_si_7","object":"subscription_item","created":1504716183,"metadata":{},"plan":{"id":"silver_plan","object":"plan","active":true,"aggregate_usage":null,"amount":1337,"billing_scheme":"per_unit","created":1466698898,"currency":"usd","interval":"month","interval_count":1,"livemode":false,"metadata":{},"nickname":"My Mock Plan","product":"stripe_mock_default_product_id","tiers":null,"tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"quantity":2,"subscription":"test_su_4"}
  ],
  "url": "/v1/hashs",
  "has_more": false
}
```

### Documentation reference
https://stripe.com/docs/api/subscription_items/list?lang=ruby
