### PR TITLE
Subscriptions: Rename start to start_date

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -365,7 +365,7 @@ module StripeMock
         canceled_at: nil,
         collection_method: 'charge_automatically',
         ended_at: nil,
-        start: 1308595038,
+        start_date: 1308595038,
         object: 'subscription',
         trial_start: 1308595038,
         trial_end: 1308681468,

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -712,7 +712,7 @@ shared_examples 'Customer Subscriptions with plans' do
       })
 
       expect(subscription.latest_invoice.payment_intent.status).to eq('requires_payment_method')
-      
+
       subscription = Stripe::Subscription.create({
         customer: customer.id,
         plan: plan.id,
@@ -1255,6 +1255,10 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(subscription.items.data.first.plan.created).to eq(1466698898)
       expect(subscription.items.data.first.plan.currency).to eq('usd')
       expect(subscription.items.data.first.quantity).to eq(2)
+    end
+
+    it "has a start_date attribute" do
+      expect(subscription).to respond_to(:start_date)
     end
   end
 


### PR DESCRIPTION
Following up #718 with a single simple test

