### PR TITLE
Include charge payment_method_details as per docs

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -193,6 +193,27 @@ module StripeMock
         currency: currency,
         destination: nil,
         fraud_details: {},
+        payment_method_details: {
+          card: {
+            brand: "visa",
+            checks: {
+              address_line1_check: nil,
+              address_postal_code_check: nil,
+              cvc_check: "pass"
+            },
+            country: "US",
+            exp_month: 12,
+            exp_year: 2013,
+            fingerprint: "3TQGpK9JoY1GgXPw",
+            funding: "credit",
+            installments: nil,
+            last4: "4242",
+            network: "visa",
+            three_d_secure: nil,
+            wallet: nil
+          },
+          type: "card"
+        },
         receipt_email: nil,
         receipt_number: nil,
         refunded: false,


### PR DESCRIPTION
Per [docs](https://stripe.com/docs/api/charges/object), this attribute is always present on charge objects. 

The actual mock charge changes are copied from an existing stale [PR](https://github.com/stripe-ruby-mock/stripe-ruby-mock/pull/741) by @drnic from a year and a half ago, however that PR has a ton of linting changes as well.

Hopefully without these changes the stripe team merges this PR and closes both of them :-)