### PR TITLE
Support metadata on subscription items

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -13,9 +13,9 @@ module StripeMock
         subscription[:items][:data] = plans.map do |plan|
           matching_item = items && items.detect { |item| [item[:price], item[:plan]].include? plan[:id] }
           if matching_item
-            quantity = matching_item[:quantity] || 1
-            id = matching_item[:id] || new_id('si')
-            params = { plan: plan, quantity: quantity, id: id }
+            matching_item[:quantity] ||= 1
+            matching_item[:id] ||= new_id('si')
+            params = matching_item.merge(plan: plan)
             params[:price] = plan if plan[:object] == "price"
             Data.mock_subscription_item(params)
           else

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -712,7 +712,7 @@ shared_examples 'Customer Subscriptions with plans' do
       })
 
       expect(subscription.latest_invoice.payment_intent.status).to eq('requires_payment_method')
-      
+
       subscription = Stripe::Subscription.create({
         customer: customer.id,
         plan: plan.id,
@@ -1324,6 +1324,27 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(customer.email).to eq('johnny@appleseed.com')
       expect(customer.subscriptions.first.plan.id).to eq('Sample5')
       expect(customer.subscriptions.first.metadata['foo']).to eq('bar')
+    end
+
+    it "saves subscription item metadata" do
+      stripe_helper.
+        create_plan(
+        :amount => 500,
+        :interval => 'month',
+        :product => product.id,
+        :currency => 'usd',
+        :id => 'Sample5'
+      )
+      customer = Stripe::Customer.create({
+        email: 'johnny@appleseed.com',
+        source: gen_card_tk
+      })
+
+      subscription = Stripe::Subscription.create(
+        customer: customer.id,
+        items: [{plan: "Sample5", metadata: {foo: 'bar'}}],
+      )
+      expect(subscription.items.data[0].metadata.to_h).to eq(foo: 'bar')
     end
   end
 end


### PR DESCRIPTION
Keep the passed-in params for subscription items instead of only allowing 3 specific params.

Another way of accomplishing this would be to add `metadata` to the allowed-list—if we're worried about invalid parameters I can change the implementation to do that instead.