### PR TITLE
Account: replace deprecated `verification` hash by `requirements`

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -34,10 +34,15 @@ module StripeMock
 
           ]
         },
-        verification: {
-          fields_needed: [],
-          due_by: nil,
-          contacted: false
+        requirements: {
+          alternatives: [],
+          current_deadline: nil,
+          currently_due: [],
+          disabled_reason: nil,
+          errors: [],
+          eventually_due: [],
+          past_due: [],
+          pending_verification: []
         },
         transfer_schedule: {
           delay_days: 7,


### PR DESCRIPTION
The verification hash has been replaced with a requirements hash, starting on version 2019-02-19

https://stripe.com/docs/upgrades#2019-02-19