### PR TITLE
Allow subscription filter on current_period values

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -125,6 +125,19 @@ module StripeMock
         end
         total
       end
+
+      def filter_by_timestamp(subscriptions, field:, value:)
+        if value.is_a?(Hash)
+          operator_mapping = { gt: :>, gte: :>=, lt: :<, lte: :<= }
+          subscriptions.filter do |sub|
+            sub[field].public_send(operator_mapping[value.keys[0]], value.values[0])
+          end
+        else
+          subscriptions.filter do |sub|
+            sub[field] == value
+          end
+        end
+      end
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -188,6 +188,12 @@ module StripeMock
         else
           subs = subs.filter {|subscription| subscription[:status] == params[:status]}
         end
+        if params[:current_period_end]
+          subs = filter_by_timestamp(subs, field: :current_period_end, value: params[:current_period_end])
+        end
+        if params[:current_period_start]
+          subs = filter_by_timestamp(subs, field: :current_period_start, value: params[:current_period_start])
+        end
 
         Data.mock_list_object(subs, params)
       end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1299,6 +1299,38 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(list.data).to be_empty
       expect(list.data.length).to eq(0)
     end
+
+    it "filters out subscriptions based on their current_period", live: true do
+      price = stripe_helper.create_price(recurring: { interval: 'month' })
+      price2 = stripe_helper.create_price(recurring: { interval: 'year' })
+
+      subscription1 = Stripe::Subscription.create(
+        customer: Stripe::Customer.create(source: gen_card_tk).id,
+        items: [{ price: price.id, quantity: 1 }]
+      )
+      subscription2 = Stripe::Subscription.create(
+        customer: Stripe::Customer.create(source: gen_card_tk).id,
+        items: [{ price: price2.id, quantity: 1 }]
+      )
+
+      list = Stripe::Subscription.list({ current_period_end: { gt: subscription1.current_period_end }})
+      expect(list.data).to contain_exactly(subscription2)
+
+      list = Stripe::Subscription.list({ current_period_end: { gte: subscription1.current_period_end }})
+      expect(list.data).to contain_exactly(subscription1, subscription2)
+
+      list = Stripe::Subscription.list({ current_period_end: { lt: subscription1.current_period_end }})
+      expect(list.data).to be_empty
+
+      list = Stripe::Subscription.list({ current_period_end: { lte: subscription1.current_period_end }})
+      expect(list.data).to contain_exactly(subscription1)
+
+      list = Stripe::Subscription.list({ current_period_start: subscription1.current_period_start })
+      expect(list.data).to contain_exactly(subscription1, subscription2)
+
+      list = Stripe::Subscription.list({ current_period_end: subscription2.current_period_end })
+      expect(list.data).to contain_exactly(subscription2)
+    end
   end
 
   describe "metadata" do


### PR DESCRIPTION
Add support for filtering on `current_period_start` and `current_period_end` as supported on Subscriptions.
Reference:
https://stripe.com/docs/api/subscriptions/list?lang=ruby#list_subscriptions-current_period_start
https://stripe.com/docs/api/subscriptions/list?lang=ruby#list_subscriptions-current_period_end