### PR TITLE
Support invoice number

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -450,7 +450,8 @@ module StripeMock
         next_payment_attempt: 1349825350,
         charge: nil,
         discount: nil,
-        subscription: nil
+        subscription: nil,
+        number: "6C41730-0001"
       }.merge(params)
       if invoice[:discount]
         invoice[:total] = [0, invoice[:subtotal] - invoice[:discount][:coupon][:amount_off]].max if invoice[:discount][:coupon][:amount_off]

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -14,6 +14,11 @@ shared_examples 'Invoice API' do
       expect(data[invoice.id]).to_not be_nil
       expect(data[invoice.id][:id]).to eq(invoice.id)
     end
+
+    it "supports invoice number" do
+      original = Stripe::Invoice.create
+      expect(original.number).to be
+    end
   end
 
   context "retrieving an invoice" do


### PR DESCRIPTION
As per the Stripe API docs, `number` is 

> A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer’s unique invoice_prefix if it is specified.

This goes some (small) way to addressing an issue identified in #670 