### PR TITLE
Fix test suite

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
---colour --format documentation
+--colour
+--format progress

--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ Patches are welcome and greatly appreciated! If you're contributing to fix a pro
 be sure to write tests that illustrate the problem being fixed.
 This will help ensure that the problem remains fixed in future updates.
 
+Note: You may need to `ulimit -n 4048` before running the test suite to get all tests to pass.
+
 ## Copyright
 
 Copyright (c) 2013 Gilbert

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -6,7 +6,9 @@ describe StripeMock::Instance do
   let(:stripe_helper) { StripeMock.create_test_helper }
 
   it_behaves_like_stripe do
-    def test_data_source(type); StripeMock.instance.send(type); end
+    def test_data_source(type)
+      StripeMock.instance.send(type)
+    end
   end
 
   before { StripeMock.start }

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -47,7 +47,7 @@ describe 'README examples' do
 
     customer_object = event.data.object
     expect(customer_object.id).to_not be_nil
-    expect(customer_object.default_card).to_not be_nil
+    expect(customer_object.default_source).to_not be_nil
     # etc.
   end
 

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -298,7 +298,6 @@ shared_examples 'Webhook Events API' do
       invoice_payment_succeeded = StripeMock.mock_webhook_event('invoice.payment_succeeded')
       expect(invoice_payment_succeeded).to be_a(Stripe::Event)
       expect(invoice_payment_succeeded.id).to_not be_nil
-      puts "invoice_payment_succeeded.data.object.lines: #{invoice_payment_succeeded.data.object.lines}"
       expect(invoice_payment_succeeded.data.object.lines.data.class).to be Array
       expect(invoice_payment_succeeded.data.object.lines.data.length).to be 1
       expect(invoice_payment_succeeded.data.object.lines.data.first).to respond_to(:plan)

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -257,7 +257,7 @@ shared_examples 'Webhook Events API' do
       expect(subscription_created_event).to be_a(Stripe::Event)
       expect(subscription_created_event.id).to_not be_nil
       expect(subscription_created_event.data.object.items.data.class).to be Array
-      expect(subscription_created_event.data.object.items.data.length).to be 2
+      expect(subscription_created_event.data.object.items.data.length).to be 1
       expect(subscription_created_event.data.object.items.data.first).to respond_to(:plan)
       expect(subscription_created_event.data.object.items.data.first.id).to eq('si_00000000000000')
     end
@@ -267,7 +267,7 @@ shared_examples 'Webhook Events API' do
       expect(subscription_deleted_event).to be_a(Stripe::Event)
       expect(subscription_deleted_event.id).to_not be_nil
       expect(subscription_deleted_event.data.object.items.data.class).to be Array
-      expect(subscription_deleted_event.data.object.items.data.length).to be 2
+      expect(subscription_deleted_event.data.object.items.data.length).to be 1
       expect(subscription_deleted_event.data.object.items.data.first).to respond_to(:plan)
       expect(subscription_deleted_event.data.object.items.data.first.id).to eq('si_00000000000000')
     end
@@ -277,7 +277,7 @@ shared_examples 'Webhook Events API' do
       expect(subscription_updated_event).to be_a(Stripe::Event)
       expect(subscription_updated_event.id).to_not be_nil
       expect(subscription_updated_event.data.object.items.data.class).to be Array
-      expect(subscription_updated_event.data.object.items.data.length).to be 2
+      expect(subscription_updated_event.data.object.items.data.length).to be 1
       expect(subscription_updated_event.data.object.items.data.first).to respond_to(:plan)
       expect(subscription_updated_event.data.object.items.data.first.id).to eq('si_00000000000000')
     end
@@ -298,10 +298,11 @@ shared_examples 'Webhook Events API' do
       invoice_payment_succeeded = StripeMock.mock_webhook_event('invoice.payment_succeeded')
       expect(invoice_payment_succeeded).to be_a(Stripe::Event)
       expect(invoice_payment_succeeded.id).to_not be_nil
+      puts "invoice_payment_succeeded.data.object.lines: #{invoice_payment_succeeded.data.object.lines}"
       expect(invoice_payment_succeeded.data.object.lines.data.class).to be Array
-      expect(invoice_payment_succeeded.data.object.lines.data.length).to be 2
+      expect(invoice_payment_succeeded.data.object.lines.data.length).to be 1
       expect(invoice_payment_succeeded.data.object.lines.data.first).to respond_to(:plan)
-      expect(invoice_payment_succeeded.data.object.lines.data.first.id).to eq('sub_00000000000000')
+      expect(invoice_payment_succeeded.data.object.lines.data.first.id).to eq('il_000000000000000000000000')
     end
   end
 end


### PR DESCRIPTION
This fixes the test suite (ran locally under ruby 3.1.2).

I was still occasionally seeing DRB-style "is recycled object" errors; didn't look further into them.

Is the suite set up on some sort of CI?