### PR TITLE
change invoice status to paid when paid = true

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -53,7 +53,12 @@ module StripeMock
         route =~ method_url
         assert_existence :invoice, $1, invoices[$1]
         charge = invoice_charge(invoices[$1])
-        invoices[$1].merge!(:paid => true, :attempted => true, :charge => charge[:id])
+        invoices[$1].merge!(
+          :paid => true,
+          :status => "paid",
+          :attempted => true,
+          :charge => charge[:id],
+        )
       end
 
       def upcoming_invoice(route, method_url, params, headers = {})

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -83,10 +83,26 @@ shared_examples 'Invoice API' do
       @invoice = @invoice.pay
       expect(@invoice.attempted).to eq(true)
       expect(@invoice.paid).to eq(true)
+      expect(@invoice.status).to eq("paid")
     end
 
     it 'creates a new charge object' do
       expect{ @invoice.pay }.to change { Stripe::Charge.list.data.count }.by 1
+    end
+
+    it 'should work with Stripe::Invoice.pay(invoice_id)' do
+      expect(@invoice.paid).to_not eq(true)
+
+      expect {
+        Stripe::Invoice.pay(@invoice.id)
+      }.to change { Stripe::Charge.list.data.count }.by 1
+
+      @invoice = Stripe::Invoice.retrieve(id: @invoice.id)
+      expect(@invoice).to_not be_nil
+
+      expect(@invoice.attempted).to eq(true)
+      expect(@invoice.paid).to eq(true)
+      expect(@invoice.status).to eq("paid")
     end
 
     it 'sets the charge attribute' do


### PR DESCRIPTION
status was always set to 'open' even after paying.

This doesn't fix voiding or draft statuses.

https://stripe.com/docs/api/invoices/object#invoice_object-status