### PR TITLE
Allow stripe-ruby 9

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '< 6'
+  gem.add_dependency 'stripe', '> 5', '< 10'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Our test suite seems okay with just bumping the gemspec. YMMV