### PR TITLE
Fix typo in account.updated webhook fixture

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/account.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/account.updated.json
@@ -10,7 +10,7 @@
       "email": "test@stripe.com",
       "statement_descriptor": "TEST",
       "details_submitted": true,
-      "charge_enabled": false,
+      "charges_enabled": false,
       "payouts_enabled": false,
       "currencies_supported": [
         "USD"


### PR DESCRIPTION
The `account.updated` webhook fixture contains a field named `charge_enabled`, but the actual field sent by stripe is named `charges_enabled`. See the [account object](https://stripe.com/docs/api/accounts/object) in the API docs