### PR TITLE
Adds error when attempting to refund a charge that has already been refunded / refunding more than the charge amount

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/charge_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/charge_helpers.rb
@@ -3,6 +3,12 @@ module StripeMock
     module Helpers
 
       def add_refund_to_charge(refund, charge)
+        if refund[:amount] + charge[:amount_refunded] > charge[:amount]
+          raise Stripe::InvalidRequestError.new(
+            "Charge #{charge[:id]} has already been refunded.",
+            'amount'
+          )
+        end
         refunds = charge[:refunds]
         refunds[:data] << refund
         refunds[:total_count] = refunds[:data].count

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -338,6 +338,17 @@ shared_examples 'Refund API' do
       expect(half.data.first.id).to eq(all_refunds.data.at(2).id)
     end
 
+    it "returns an InvalidRequestError when attempting to refund more than the original charge amount" do
+      charge = Stripe::Charge.create(
+        amount: 1000,
+        currency: 'usd',
+        source: stripe_helper.generate_card_token
+      )
+      expect {
+        Stripe::Refund.create(charge: charge.id, amount: 2000)
+      }.to raise_error(Stripe::InvalidRequestError)
+    end
+
     describe "idempotency" do
       let(:customer) { Stripe::Customer.create(email: 'johnny@appleseed.com') }
       let(:charge) do


### PR DESCRIPTION
Reverts stripe-ruby-mock/stripe-ruby-mock#888
Readds changes to throw error when attempting to refund a charge for more than has been charged already or more than the original charge amount.