### PR TITLE
Adds support for stripe-ruby v10

### DIFF
--- a/lib/stripe_mock/api/client.rb
+++ b/lib/stripe_mock/api/client.rb
@@ -27,7 +27,7 @@ module StripeMock
 
   private
 
-  def self.redirect_to_mock_server(method, url, api_key: nil, api_base: nil, params: {}, headers: {})
+  def self.redirect_to_mock_server(method, url, api_key: nil, api_base: nil, usage: [], params: {}, headers: {})
     handler = Instance.handler_for_method_url("#{method} #{url}")
 
     if mock_error = client.error_queue.error_for_handler_name(handler[:name])

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -109,7 +109,7 @@ module StripeMock
       @base_strategy = TestStrategies::Base.new
     end
 
-    def mock_request(method, url, api_key: nil, api_base: nil, params: {}, headers: {})
+    def mock_request(method, url, api_key: nil, api_base: nil, usage: [], params: {}, headers: {})
       return {} if method == :xtest
 
       api_key ||= (Stripe.api_key || DUMMY_API_KEY)

--- a/spec/shared_stripe_examples/bank_token_examples.rb
+++ b/spec/shared_stripe_examples/bank_token_examples.rb
@@ -28,20 +28,19 @@ shared_examples 'Bank Account Token Mocking' do
     expect(bank_token).to match /^test_btok/
   end
 
-  it "assigns the generated bank account to a new recipient" do
+  it "assigns the generated bank account to a new customer" do
     bank_token = StripeMock.generate_bank_token(
       :bank_name => "Bank Token Mocking",
       :last4 => "7777"
     )
 
-    recipient = Stripe::Recipient.create({
+    customer = Stripe::Customer.create({
       name: "Fred Flinstone",
-      type: "individual",
       email: 'blah@domain.co',
-      bank_account: bank_token
+      source: bank_token
     })
-    expect(recipient.active_account.last4).to eq("7777")
-    expect(recipient.active_account.bank_name).to eq("Bank Token Mocking")
+    expect(customer.sources.first.last4).to eq("7777")
+    expect(customer.sources.first.bank_name).to eq("Bank Token Mocking")
   end
 
   it "retrieves a created token" do

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -154,7 +154,8 @@ shared_examples 'Invoice API' do
     describe 'parameter validation' do
       it 'fails without parameters' do
         expect { Stripe::Invoice.upcoming() }.to raise_error {|e|
-          expect(e).to be_a(ArgumentError) }
+          expect(e).to be_a(Stripe::InvalidRequestError)
+          expect(e.message).to eq('Missing required param: customer if subscription is not provided')}
       end
 
       it 'fails without a valid customer' do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -687,7 +687,7 @@ shared_examples 'Customer Subscriptions with plans' do
       customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk)
 
       sub = Stripe::Subscription.create({ items: { '0' => { plan: 'silver' } }, customer: customer.id })
-      sub.delete(at_period_end: true)
+      sub.cancel(at_period_end: true)
 
       expect(sub.cancel_at_period_end).to be_truthy
       expect(sub.save).to be_truthy
@@ -752,7 +752,7 @@ shared_examples 'Customer Subscriptions with plans' do
       customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
 
       subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
-      subscription.delete
+      subscription.cancel
 
       expect { subscription.save }.to raise_error { |e|
         expect(e).to be_a(Stripe::InvalidRequestError)
@@ -765,7 +765,7 @@ shared_examples 'Customer Subscriptions with plans' do
       customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk)
 
       sub = Stripe::Subscription.create({ items: [ { plan: plan.id } ], customer: customer.id })
-      sub.delete(at_period_end: true)
+      sub.cancel(at_period_end: true)
 
       expect(sub.cancel_at_period_end).to be_truthy
       expect(sub.save).to be_truthy
@@ -1180,7 +1180,7 @@ shared_examples 'Customer Subscriptions with plans' do
       customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
 
       sub = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
-      result = sub.delete
+      result = sub.cancel
 
       expect(result.status).to eq('canceled')
       expect(result.cancel_at_period_end).to eq false
@@ -1247,7 +1247,7 @@ shared_examples 'Customer Subscriptions with plans' do
     customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "trial")
 
     sub = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
-    result = sub.delete(at_period_end: true)
+    result = sub.cancel(at_period_end: true)
 
     expect(result.status).to eq('trialing')
 
@@ -1331,7 +1331,7 @@ shared_examples 'Customer Subscriptions with plans' do
     it "does not include canceled subscriptions by default" do
       customer = Stripe::Customer.create(source: gen_card_tk)
       subscription = Stripe::Subscription.create({ plan: plan.id, customer: customer.id })
-      subscription.delete
+      subscription.cancel
 
       list = Stripe::Subscription.list({customer: customer.id})
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'set'
 
-gem 'rspec', '~> 3.1'
+gem 'rspec', '~> 3.12'
 require 'rspec'
 require 'stripe'
 require 'stripe_mock'

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '< 6'
+  gem.add_dependency 'stripe', '> 5', '< 11'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 
-  gem.add_development_dependency 'rspec', '~> 3.7.0'
+  gem.add_development_dependency 'rspec', '~> 3.12'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
   gem.add_development_dependency 'thin', '~> 1.8.1'
 end


### PR DESCRIPTION
Fixed deprecated methods in specs:

- Deprecate `delete` method on `Subscription` resource. Please use `cancel` method instead. (since v7)
- Deprecated `Recipient` resource (since v7). Using customer object instead in Bank Account token test.
- Upcoming Invoice raises `Stripe::InvalidRequestError` instead of `ArgumentError` if no argument is given.