### PR TITLE
Add `ui_mode` and `client_secret` to checkout session to support embedded checkout

### DIFF
--- a/lib/stripe_mock/request_handlers/checkout_session.rb
+++ b/lib/stripe_mock/request_handlers/checkout_session.rb
@@ -126,7 +126,8 @@ module StripeMock
             subscription: nil,
             success_url: params[:success_url],
             total_details: nil,
-            url: URI.join(StripeMock.checkout_base, id).to_s
+            url: URI.join(StripeMock.checkout_base, id).to_s,
+            ui_mode: params[:ui_mode],
           }
         end
 

--- a/lib/stripe_mock/request_handlers/checkout_session.rb
+++ b/lib/stripe_mock/request_handlers/checkout_session.rb
@@ -128,6 +128,7 @@ module StripeMock
             total_details: nil,
             url: URI.join(StripeMock.checkout_base, id).to_s,
             ui_mode: params[:ui_mode],
+            client_secret: nil,
           }
         end
 


### PR DESCRIPTION
Addresses #895.

I've never coded anything using this library before, so I've likely made a mistake.

Stripe changelog describing new mode: https://docs.stripe.com/changelog#october-6,-2023

Embedded mode quickstart: https://docs.stripe.com/checkout/embedded/quickstart?lang=ruby

Stripe API doc: https://docs.stripe.com/api/checkout/sessions/create