### PR TITLE
Rebase our customizations atop latest stripe-ruby-mock

### DIFF
--- a/bin/stripe-mock-server
+++ b/bin/stripe-mock-server
@@ -11,6 +11,7 @@ opts = Trollop::options do
   opt :server, "Server to use", :type => :string, :default => 'thin'
   opt :debug, "Request and response output", :default => true
   opt :pid_path, "Location to put server pid file", :type => :string, :default => './stripe-mock-server.pid'
+  opt :require, "Extra path to require when loading the server; can be specified multiple times", :type => :string, :multi => true
 end
 
 require 'stripe_mock'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -382,7 +382,8 @@ module StripeMock
               currency: StripeMock.default_currency
             },
             quantity: 1
-          }]
+          }],
+          has_more: false
         },
         cancel_at_period_end: false,
         canceled_at: nil,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -374,10 +374,7 @@ module StripeMock
           data: [{
             id: 'si_1AwFf62eZvKYlo2C9u6Dhf9',
             created: 1504035973,
-            metadata: {
-              # Added for avoiding nil exception
-              company_deleted: false
-            },
+            metadata: {},
             object: 'subscription_item',
             plan: {
               amount: 999,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -375,6 +375,7 @@ module StripeMock
             id: 'si_1AwFf62eZvKYlo2C9u6Dhf9',
             created: 1504035973,
             metadata: {
+              # Added for avoiding nil exception
               company_deleted: false
             },
             object: 'subscription_item',
@@ -385,6 +386,7 @@ module StripeMock
             },
             quantity: 1
           }],
+          # Added missing attribute - it does not have another page of items
           has_more: false
         },
         cancel_at_period_end: false,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -374,7 +374,9 @@ module StripeMock
           data: [{
             id: 'si_1AwFf62eZvKYlo2C9u6Dhf9',
             created: 1504035973,
-            metadata: {},
+            metadata: {
+              company_deleted: false
+            },
             object: 'subscription_item',
             plan: {
               amount: 999,

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -56,24 +56,6 @@ module StripeMock
           params.merge!({status: 'trialing', current_period_end: end_time, trial_start: start_time, trial_end: end_time, billing_cycle_anchor: options[:billing_cycle_anchor] || created_time})
         end
 
-        # Support updating subscription with multiple plan items
-        items = options[:items] || []
-        items = items.values if items.respond_to?(:values)
-        if items.any?
-          items_data = []
-          items.each do |item|
-            quantity = item[:quantity] || 1
-            items_data.push(Data.mock_subscription_item(plan: plan, quantity: quantity, created: Time.now.utc.to_i))
-          end
-          params[:items] = Data.mock_list_object(items_data)
-          if items_data.size == 1
-            params.merge!(:plan => items_data[0][:plan], :quantity => items_data[0][:quantity])
-          elsif items_data.size > 1
-            params.delete(:plan)
-            params.delete(:quantity)
-          end
-        end
-
         params
       end
 

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -56,6 +56,24 @@ module StripeMock
           params.merge!({status: 'trialing', current_period_end: end_time, trial_start: start_time, trial_end: end_time, billing_cycle_anchor: options[:billing_cycle_anchor] || created_time})
         end
 
+        # Support updating subscription with multiple plan items
+        items = options[:items] || []
+        items = items.values if items.respond_to?(:values)
+        if items.any?
+          items_data = []
+          items.each do |item|
+            quantity = item[:quantity] || 1
+            items_data.push(Data.mock_subscription_item(plan: plan, quantity: quantity, created: Time.now.utc.to_i))
+          end
+          params[:items] = Data.mock_list_object(items_data)
+          if items_data.size == 1
+            params.merge!(:plan => items_data[0][:plan], :quantity => items_data[0][:quantity])
+          elsif items_data.size > 1
+            params.delete(:plan)
+            params.delete(:quantity)
+          end
+        end
+
         params
       end
 

--- a/lib/stripe_mock/server.rb
+++ b/lib/stripe_mock/server.rb
@@ -3,10 +3,16 @@ require 'drb/drb'
 module StripeMock
   class Server
     def self.start_new(opts)
-      puts "Starting StripeMock server on port #{opts[:port] || 4999}"
+      host = opts.fetch(:host, "0.0.0.0")
+      port = opts.fetch(:port, 4999)
+      extra_requires = opts.fetch(:require, [])
 
-      host = opts.fetch :host,'0.0.0.0'
-      port = opts.fetch :port, 4999
+      extra_requires.each do |path|
+        puts "Requiring additional path: #{path}"
+        require(path)
+      end
+
+      puts "Starting StripeMock server on port #{port}"
 
       DRb.start_service "druby://#{host}:#{port}", Server.new
       DRb.thread.join
@@ -88,6 +94,5 @@ module StripeMock
     def upsert_stripe_object(object, attributes)
       @instance.upsert_stripe_object(object, attributes)
     end
-
   end
 end


### PR DESCRIPTION
This rebases our customizations atop the latest version of the gem. This is based on the stripe-ruby-mock/init-v4 branch, where it appears current work is happening. I squashed a few intermittent commits out, and a few others were dropped because a corresponding change had already been made upstream.

The questions we need to answer are:
1. What of this can, and thus should, be upstreamed?
2. What is specific to our setup, and thus does not belong in the gem, but rather in our code/tests?