### PR TITLE
Add `require` option to require additional file

### DIFF
--- a/bin/stripe-mock-server
+++ b/bin/stripe-mock-server
@@ -11,6 +11,7 @@ opts = Trollop::options do
   opt :server, "Server to use", :type => :string, :default => 'thin'
   opt :debug, "Request and response output", :default => true
   opt :pid_path, "Location to put server pid file", :type => :string, :default => './stripe-mock-server.pid'
+  opt :require, "Extra path to require when loading the server; can be specified multiple times", :type => :string, :multi => true
 end
 
 require 'stripe_mock'

--- a/lib/stripe_mock/server.rb
+++ b/lib/stripe_mock/server.rb
@@ -3,10 +3,16 @@ require 'drb/drb'
 module StripeMock
   class Server
     def self.start_new(opts)
-      puts "Starting StripeMock server on port #{opts[:port] || 4999}"
+      host = opts.fetch(:host, "0.0.0.0")
+      port = opts.fetch(:port, 4999)
+      extra_requires = opts.fetch(:require, [])
 
-      host = opts.fetch :host,'0.0.0.0'
-      port = opts.fetch :port, 4999
+      extra_requires.each do |path|
+        puts "Requiring additional path: #{path}"
+        require(path)
+      end
+
+      puts "Starting StripeMock server on port #{port}"
 
       DRb.start_service "druby://#{host}:#{port}", Server.new
       DRb.thread.join
@@ -88,6 +94,5 @@ module StripeMock
     def upsert_stripe_object(object, attributes)
       @instance.upsert_stripe_object(object, attributes)
     end
-
   end
 end


### PR DESCRIPTION
When booting the stripe-mock-server it can be useful to have Ruby `require` in additional files if you need to patch `StripeMock` in some way. This is mostly useful for differences when you're running on an older version of the Stripe API and need to tweak `StripeMock`'s behavior until your Stripe API version is upgraded to be compatible.

When using `StripeMock` directly within a Rails app, for example, this is unneeded as you can do the same thing via a Rails initializer file. But if running the `StripeMock` server standalone - for use with front end tests, for example, you might pass this new flag like this:

```console
--require config/initializers/stripe_ruby_mock
```