### PR TITLE
Add has_more to Subscription.items data

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -382,7 +382,8 @@ module StripeMock
               currency: StripeMock.default_currency
             },
             quantity: 1
-          }]
+          }],
+          has_more: false
         },
         cancel_at_period_end: false,
         canceled_at: nil,


### PR DESCRIPTION
As was [discussed](https://github.com/stripe-ruby-mock/stripe-ruby-mock/pull/902/files#diff-1667108aad075636c86a6554f0c8cbec156997829b8bf36291d17f74a615b444R390) in #902.