### PR TITLE
Allow Stripe SDK v11

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '< 11'
+  gem.add_dependency 'stripe', '> 5', '< 12'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Which launched a couple weeks ago, and should be backward compatible with 10, etc…

[Strike SDK Changelog](https://github.com/stripe/stripe-ruby/blob/master/CHANGELOG.md#1100---2024-04-10)