### PR TITLE
fix calls to use raise instead of throw

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -166,7 +166,7 @@ module StripeMock
         end
 
         if params[:transfer_data] && !params[:transfer_data].empty?
-          throw Stripe::InvalidRequestError.new(missing_param_message("transfer_data[destination]")) unless params[:transfer_data][:destination]
+          raise Stripe::InvalidRequestError.new(missing_param_message("transfer_data[destination]")) unless params[:transfer_data][:destination]
           subscription[:transfer_data] = params[:transfer_data].dup
           subscription[:transfer_data][:amount_percent] ||= 100
         end


### PR DESCRIPTION
* fix calls to use raise instead of throw
* make sure to call raise Stripe::InvalidRequestError.new(error, param) (note: call to new + 'param')

fixes #906