### PR TITLE
Better tests for payout

### DIFF
--- a/lib/stripe_mock/request_handlers/payouts.rb
+++ b/lib/stripe_mock/request_handlers/payouts.rb
@@ -10,13 +10,13 @@ module StripeMock
       end
 
       def new_payout(route, method_url, params, headers)
-        id = new_id('po')
+        params[:id] ||= new_id("po")
 
         unless params[:amount].is_a?(Integer) || (params[:amount].is_a?(String) && /^\d+$/.match(params[:amount]))
           raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', http_status: 400)
         end
 
-        payouts[id] = Data.mock_payout(params.merge :id => id)
+        payouts[params[:id]] = Data.mock_payout(params.merge :id => params[:id])
       end
 
       def update_payout(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/payouts.rb
+++ b/lib/stripe_mock/request_handlers/payouts.rb
@@ -12,7 +12,7 @@ module StripeMock
       def new_payout(route, method_url, params, headers)
         params[:id] ||= new_id("po")
 
-        unless params[:amount].is_a?(Integer) || (params[:amount].is_a?(String) && /^\d+$/.match(params[:amount]))
+        unless (params[:amount].is_a?(Integer) && params[:amount].positive?) || (params[:amount].is_a?(String) && /^\d+$/.match(params[:amount]))
           raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', http_status: 400)
         end
 

--- a/spec/shared_stripe_examples/payout_examples.rb
+++ b/spec/shared_stripe_examples/payout_examples.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 shared_examples 'Payout API' do
 
   it "creates a stripe payout" do
-    payout = Stripe::Payout.create(amount:  "100", currency: "usd")
+    payout = Stripe::Payout.create(amount: 100, currency: "usd")
 
     expect(payout.id).to match(/^test_po/)
-    expect(payout.amount).to eq('100')
+    expect(payout.amount).to eq(100)
     expect(payout.currency).to eq('usd')
     expect(payout.metadata.to_hash).to eq({})
   end
@@ -14,7 +14,7 @@ shared_examples 'Payout API' do
   describe "listing payouts" do
     before do
       3.times do
-        Stripe::Payout.create(amount: "100", currency: "usd")
+        Stripe::Payout.create(amount: 100, currency: "usd")
       end
     end
 
@@ -28,7 +28,7 @@ shared_examples 'Payout API' do
   end
 
   it "retrieves a stripe payout" do
-    original = Stripe::Payout.create(amount:  "100", currency: "usd")
+    original = Stripe::Payout.create(amount: 100, currency: "usd")
     payout = Stripe::Payout.retrieve(original.id)
 
     expect(payout.id).to eq(original.id)
@@ -37,8 +37,15 @@ shared_examples 'Payout API' do
     expect(payout.metadata.to_hash).to eq(original.metadata.to_hash)
   end
 
-  it "updates a stripe payout" do
-    original = Stripe::Payout.create(amount:  "100", currency: "usd")
+  it "updates a stripe payout using method" do
+    original = Stripe::Payout.create(amount: 100, currency: "usd")
+    updated = Stripe::Payout.update(original.id, amount: 1337)
+    payout = Stripe::Payout.retrieve(original.id)
+    expect(payout.amount).to eq(1337)
+  end
+
+  it "updates a stripe payout object" do
+    original = Stripe::Payout.create(amount: 100, currency: "usd")
     payout = Stripe::Payout.retrieve(original.id)
 
     expect(payout.id).to eq(original.id)
@@ -58,17 +65,18 @@ shared_examples 'Payout API' do
   end
 
   it 'when amount is not integer', live: true do
-    expect { Stripe::Payout.create(amount: '400.2',
+    expect { Stripe::Payout.create(amount: 400.2,
                                        currency: 'usd',
                                        description: 'Payout for test@example.com') }.to raise_error { |e|
       expect(e).to be_a Stripe::InvalidRequestError
       expect(e.param).to eq('amount')
+      expect(e.message).to match(/^Invalid.*integer/)
       expect(e.http_status).to eq(400)
     }
   end
 
   it 'when amount is negative', live: true do
-    expect { Stripe::Payout.create(amount: '-400',
+    expect { Stripe::Payout.create(amount: -400,
                                      currency: 'usd',
                                      description: 'Payout for test@example.com') }.to raise_error { |e|
       expect(e).to be_a Stripe::InvalidRequestError


### PR DESCRIPTION
* Update object id during creation in the same way as other tests
* Set amount as integer like in other tests
* Handle negative integers in test
* Test for using payout.update, previous test only tested .save (deprecated in Stripe gem v8)