### PR TITLE
Add capabilities to mock account data

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -11,6 +11,14 @@ module StripeMock
         display_name: "Stripe.com",
         timezone: "US/Pacific",
         details_submitted: false,
+        capabilities: {
+          bank_transfer_payments: "active",
+          card_payments: "active",
+          ideal_payments: "active",
+          sepa_bank_transfer_payments: "active",
+          sepa_debit_payments:"active",
+          transfers:"active"
+        },
         charges_enabled: false,
         payouts_enabled: false,
         currencies_supported: [


### PR DESCRIPTION
### Why
Stripe returns a `capabilities` property on the `Account`, [shown here](https://docs.stripe.com/api/accounts/object#account_object-capabilities).

I wasn't sure if I needed to add a test, from a quick look I couldn't see tests for other properties on the mock data. More than happy to add a test if required!