### PR TITLE
Adds DRB as a dependency in preparation to Ruby 3.4.0

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'stripe', '> 5', '< 13'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
+  gem.add_dependency 'drb', '>= 2.0.4', '< 3'
 
   gem.add_development_dependency 'rspec', '~> 3.13.0'
   gem.add_development_dependency 'thin', '~> 1.8.1'


### PR DESCRIPTION
See https://stdgems.org/drb/

Should also silence annoying warnings for those of us in 3.3