### PR TITLE
Adds `net_available` to instant available balance

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1141,7 +1141,13 @@ module StripeMock
               card: 25907032203,
               bank_account: 108476658,
               bitcoin_receiver: 1545182
-            }
+            },
+            net_available: [
+              {
+                amount: usd_balance,
+                destination: 'test_ba_default'
+              }
+            ]
           }],
         connect_reserved: [
           {


### PR DESCRIPTION
This is related to Instant Payouts. [more info here](https://docs.stripe.com/connect/instant-payouts?dashboard-or-api=api#initiate-an-instant-payout)

> The property `instant_available.net_available` is the connected account’s instant balance net of platform fees for each instantly available destination. You must use this field if you’re monetising with Application Fees.

I added this property directly into `mock_balance`. Is it necessary to check for the expand param and include it dynamically instead? This is just an optional [includable property](https://docs.stripe.com/expand#includable-properties), so it's different than let's say, expanding customer. The latter will replace an ID for a customer object. 