### PR TITLE
Adds discout amount to invoice

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -462,7 +462,8 @@ module StripeMock
         charge: nil,
         discount: nil,
         subscription: nil,
-        number: "6C41730-0001"
+        number: "6C41730-0001",
+        total_discount_amounts: []
       }.merge(params)
       if invoice[:discount]
         invoice[:total] = [0, invoice[:subtotal] - invoice[:discount][:coupon][:amount_off]].max if invoice[:discount][:coupon][:amount_off]

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -487,6 +487,7 @@ module StripeMock
         amount: 1000,
         currency: currency,
         discountable: false,
+        discount_amounts: [],
         proration: false,
         period: {
           start: 1349738920,


### PR DESCRIPTION
Since Stripe allows discounts to be applied to line items individually, this PR adds [discount_amounts](https://docs.stripe.com/api/invoice-line-item/object#invoice_line_item_object-discount_amounts) to Line Items and [total_discount_amounts](https://docs.stripe.com/api/invoice-line-item/object#invoice_line_item_object-discount_amounts) to the Invoice. I needed to add these since I was getting `undefined method error` when trying to access these attributes.