### PR TITLE
Allow `:cancel_url` nil in create Checkout Session

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1418,7 +1418,7 @@ module StripeMock
         id: cs_id,
         object: 'checkout.session',
         billing_address_collection: nil,
-        cancel_url: 'https://example.com/cancel',
+        cancel_url: nil,
         client_reference_id: nil,
         customer: nil,
         customer_email: nil,

--- a/lib/stripe_mock/request_handlers/checkout_session.rb
+++ b/lib/stripe_mock/request_handlers/checkout_session.rb
@@ -12,9 +12,7 @@ module StripeMock
         def new_session(route, method_url, params, headers)
           id = params[:id] || new_id('cs')
 
-          [:cancel_url, :success_url].each do |p|
-            require_param(p) if params[p].nil? || params[p].empty?
-          end
+          require_param(:success_url) if params[:success_url].nil? || params[:success_url].empty?
 
           line_items = nil
           if params[:line_items]

--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -121,7 +121,6 @@ module StripeMock
             amount: 500,
             currency: 'usd',
           }],
-          cancel_url: "https://example.com/cancel",
           success_url: "https://example.com/success",
         }.merge(params)
       end

--- a/spec/shared_stripe_examples/checkout_session_examples.rb
+++ b/spec/shared_stripe_examples/checkout_session_examples.rb
@@ -11,7 +11,6 @@ shared_examples "Checkout Session API" do
     session = Stripe::Checkout::Session.create(
       payment_method_types: ["card"],
       line_items: line_items,
-      cancel_url: "https://example.com/cancel",
       success_url: "https://example.com/success"
     )
 
@@ -28,7 +27,6 @@ shared_examples "Checkout Session API" do
         session = Stripe::Checkout::Session.create(
           customer: "customer_id",
           success_url: "localhost/nada",
-          cancel_url: "localhost/nada",
           payment_method_types: ["card"],
         )
       end.to raise_error(Stripe::InvalidRequestError, /line_items/i)
@@ -40,7 +38,6 @@ shared_examples "Checkout Session API" do
     session = Stripe::Checkout::Session.create(
       mode: "setup",
       payment_method_types: ["card"],
-      cancel_url: "https://example.com/cancel",
       success_url: "https://example.com/success"
     )
 
@@ -55,7 +52,6 @@ shared_examples "Checkout Session API" do
         session = Stripe::Checkout::Session.create(
           customer: "customer_id",
           success_url: "localhost/nada",
-          cancel_url: "localhost/nada",
           payment_method_types: ["card"],
           mode: "subscription",
         )
@@ -86,7 +82,6 @@ shared_examples "Checkout Session API" do
     it "can expand setup_intent" do
       initial_session = Stripe::Checkout::Session.create(
         mode: "setup",
-        cancel_url: "https://example.com",
         success_url: "https://example.com",
         payment_method_types: ["card"]
       )


### PR DESCRIPTION
Removed `:cancel_url` from required params because it is not required now.
https://docs.stripe.com/api/checkout/sessions/create?api-version=2024-06-20&lang=curl