### PR TITLE
Updates customer retrieve payments mechanism

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -189,6 +189,7 @@ module StripeMock
           metadata: {},
           type: 'card'
         )
+        base
       end
 
       def retrieve_payment_method(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -164,30 +164,15 @@ module StripeMock
 
       # Helper to wrap a legacy source into a temporary PaymentMethod object
       def legacy_source_to_payment_method(source)
-        {
+        base = Data.mock_payment_method({}) || {}
+        base.merge(
           id: source[:id],
           object: 'payment_method',
-          allow_redisplay: 'unspecified',
-          billing_details: {
-            address: {
-              city: nil,
-              country: nil,
-              line1: nil,
-              line2: nil,
-              postal_code: nil,
-              state: nil
-            },
-            email: nil,
-            name: nil,
-            phone: nil,
-          },
-          card: source.clone,  # embed the legacy source data as the card subobject
+          card: source.clone,    # overwrite with the legacy source as the card subobject
           created: Time.now.to_i,
           customer: source[:customer],
-          livemode: false,
-          metadata: {},
           type: 'card'
-        }
+        )
       end
 
       def retrieve_payment_method(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -178,7 +178,7 @@ module StripeMock
         if customer[:sources] && customer[:sources][:data]
           source = customer[:sources][:data].detect { |src| src[:id] == payment_method_id }
           if source && source[:customer] == customer_id
-            return source
+            return source.is_a?(Hash) ? source.clone : source.to_h
           end
         end
 

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -164,32 +164,12 @@ module StripeMock
 
       # Helper to wrap a legacy source into a temporary PaymentMethod object
       def legacy_source_to_payment_method(source)
-        base = Data.mock_payment_method({}) || {}
-        base.merge(
-          id: source[:id],
-          object: 'payment_method',
-          allow_redisplay: 'unspecified',
-          billing_details: {
-            address: {
-              city: nil,
-              country: nil,
-              line1: nil,
-              line2: nil,
-              postal_code: nil,
-              state: nil
-            },
-            email: nil,
-            name: nil,
-            phone: nil
-          },
-          card: source.clone,    # overwrite with the legacy source as the card subobject
-          created: Time.now.to_i,
-          customer: source[:customer],
-          livemode: false,
-          metadata: {},
-          type: 'card'
-        )
-        base
+        Data.mock_payment_method({id: source[:id],
+        card: source.clone,    # overwrite with the legacy source as the card subobject
+        created: Time.now.to_i,
+        customer: source[:customer],
+        type: 'card'}) || {}
+
       end
 
       def retrieve_payment_method(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -168,9 +168,25 @@ module StripeMock
         base.merge(
           id: source[:id],
           object: 'payment_method',
+          allow_redisplay: 'unspecified',
+          billing_details: {
+            address: {
+              city: nil,
+              country: nil,
+              line1: nil,
+              line2: nil,
+              postal_code: nil,
+              state: nil
+            },
+            email: nil,
+            name: nil,
+            phone: nil
+          },
           card: source.clone,    # overwrite with the legacy source as the card subobject
           created: Time.now.to_i,
           customer: source[:customer],
+          livemode: false,
+          metadata: {},
           type: 'card'
         )
       end

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -58,9 +58,9 @@ module StripeMock
         allowed_params = [:customer]
 
         id = method_url.match(route)[1]
-  
+
         assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
-  
+
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })
         payment_methods[id].clone

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -58,11 +58,19 @@ module StripeMock
         allowed_params = [:customer]
 
         id = method_url.match(route)[1]
-
-        assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
-
+  
+        customer = assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
+  
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })
+  
+        customer[:sources] ||= { data: [], total_count: 0 }
+  
+        unless customer[:sources][:data].any? { |source| source[:id] == id }
+          customer[:sources][:data] << payment_methods[id]
+          customer[:sources][:total_count] += 1
+        end
+  
         payment_methods[id].clone
       end
 

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -59,18 +59,10 @@ module StripeMock
 
         id = method_url.match(route)[1]
   
-        customer = assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
+        assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
   
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })
-  
-        customer[:sources] ||= { data: [], total_count: 0 }
-  
-        unless customer[:sources][:data].any? { |source| source[:id] == id }
-          customer[:sources][:data] << payment_methods[id]
-          customer[:sources][:total_count] += 1
-        end
-  
         payment_methods[id].clone
       end
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -535,4 +535,27 @@ shared_examples 'Customer API' do
     customer = Stripe::Customer.retrieve("test_customer_update")
     expect(customer.discount).to be nil
   end
+
+  it "retrieves a stripe customers payment method" do
+    payment_method = Stripe::PaymentMethod.create({
+      type: 'card',
+      card: {
+        number: '4242424242424242',
+        exp_month: 12,
+        exp_year: 2024,
+        cvc: 123
+      }
+    })
+
+    customer = Stripe::Customer.create({
+      email: 'johnny@appleseed.com',
+      invoice_settings: {
+        default_payment_method: payment_method.id
+      },
+      description: "a description"
+    })
+
+    retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, payment_method.id)
+    expect(retrieved_payment_method.id).to eq(payment_method.id)
+  end
 end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -565,7 +565,6 @@ shared_examples 'Customer API' do
       description: "a description"
     })
 
-    expect { customer.source }.to raise_error
     retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, customer.sources.data.first.id)
     expect(retrieved_payment_method.id).to eq(customer.sources.data.first.id)
   end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -549,11 +549,10 @@ shared_examples 'Customer API' do
 
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      invoice_settings: {
-        default_payment_method: payment_method.id
-      },
       description: "a description"
     })
+
+    payment_method.attach(customer: customer.id)
 
     retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, payment_method.id)
     expect(retrieved_payment_method.id).to eq(payment_method.id)

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -557,4 +557,17 @@ shared_examples 'Customer API' do
     retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, payment_method.id)
     expect(retrieved_payment_method.id).to eq(payment_method.id)
   end
+
+  it "retrives a stripe customers payment method with a default card" do
+    customer = Stripe::Customer.create({
+      email: 'johnny@appleseed.com',
+      source: gen_card_tk,
+      description: "a description"
+    })
+
+    expect { customer.source }.to raise_error
+    retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, customer.sources.data.first.id)
+    expect(retrieved_payment_method.id).to eq(customer.sources.data.first.id)
+  end
+
 end


### PR DESCRIPTION
I ended up needing to create a new mocked object to match with stripes implementation. This change mocks the payment method object and fills in the card details so that the hash can be accessed by our serializer. We needed the full payment method object to be returned to have the object in our serializer.

To test:

```
Bundle install
bundle rspec spec/instance.rb
```

This Branch was tested against our own external test suite and passed.