### PR TITLE
Add drb gem to Gemspec

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'stripe', '> 5', '< 13'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
+  gem.add_dependency 'drb', '~> 2.2.1'
 
   gem.add_development_dependency 'rspec', '~> 3.13.0'
   gem.add_development_dependency 'thin', '~> 1.8.1'


### PR DESCRIPTION
In Ruby 3.4, several [gems are removed from the default gem list](https://stdgems.org/new-in/3.4/).

That means that calling "require 'gem'" will fail if they aren't explicitly installed via dependencies or a Gemfile.

`stripe-ruby-mock` calls require on 'drb' which is one of these gems. That means anyone using Ruby 3.3 will see a warning, and with 3.4 an error.

This PR adds 'drb' to the dependencies in the gemspec. I chose to use the latest version with flexibility on the patch release, but let me know if another specification could be better.