### PR TITLE
Add support for setting pause_collection

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -287,6 +287,10 @@ module StripeMock
           end
         end
 
+        if params[:pause_collection]
+          subscription[:pause_collection] = { resumes_at: nil }.merge(params[:pause_collection])
+        end
+
         if params[:trial_period_days]
           subscription[:status] = 'trialing'
         end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1170,7 +1170,35 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(sub.billing_cycle_anchor).to be_a(Integer)
     end
 
+    it "accepts pause_collection with an explicit resumes_at set" do
+      customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
+      subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+      resumes_at = Time.now.utc.to_i + 3600
 
+      subscription.pause_collection = {
+        behavior: 'mark_uncollectible',
+        resumes_at: resumes_at
+      }
+
+      subscription.save
+
+      expect(subscription.pause_collection.behavior).to eq('mark_uncollectible')
+      expect(subscription.pause_collection.resumes_at).to eq(resumes_at)
+    end
+
+    it "accepts pause_collection without an explicit resumes_at set" do
+      customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
+      subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+
+      subscription.pause_collection = {
+        behavior: 'mark_uncollectible'
+      }
+
+      subscription.save
+
+      expect(subscription.pause_collection.behavior).to eq('mark_uncollectible')
+      expect(subscription.pause_collection.resumes_at).to be_nil
+    end
   end
 
   context "cancelling a subscription" do


### PR DESCRIPTION
## What

Allows setting and retrieving the `pause_collection` attribute to pause payment collection as [described here](https://docs.stripe.com/billing/subscriptions/pause-payment).

## How

The `resumes_at` attribute is optional and should return `nil` if only `behavior` is set, so I've had to handle this in the request handler.