### PR TITLE
Add support for setting cancellation_details

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -420,6 +420,11 @@ module StripeMock
         cancel_at_period_end: false,
         canceled_at: nil,
         collection_method: 'charge_automatically',
+        cancellation_details: {
+          comment: nil,
+          feedback: nil,
+          reason: nil
+        },
         ended_at: nil,
         start_date: 1308595038,
         object: 'subscription',

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -46,6 +46,17 @@ module StripeMock
           params.merge!(cancel_at_period_end: false, canceled_at: nil)
         end
 
+        options.fetch(:cancellation_details, {}).each do |key, value|
+          next if value.nil?
+
+          if params[:cancel_at_period_end]
+            params[:cancellation_details] ||= {}
+            params[:cancellation_details][key] = value
+          else
+            raise Stripe::InvalidRequestError.new("`cancellation_details` can only be set on subscriptions that are set to cancel.", "cancellation_details", http_status: 400)
+          end
+        end
+
         # TODO: Implement coupon logic
 
         if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"


### PR DESCRIPTION
## What

Makes it possible to set `cancellation_details` when marking a subscription for cancellation:
https://docs.stripe.com/api/subscriptions/update#update_subscription-cancellation_details
