### PR TITLE
Add missing schedule field to subscription object

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -426,6 +426,7 @@ module StripeMock
           reason: nil
         },
         ended_at: nil,
+        schedule: nil,
         start_date: 1308595038,
         object: 'subscription',
         trial_start: 1308595038,


### PR DESCRIPTION
## What

Adds missing [`schedule`](https://docs.stripe.com/api/subscriptions/object#subscription_object-schedule) field that is set when a subscription is managed by a schedule.