### PR TITLE
Add code filter to PromotionCode list API

### DIFF
--- a/lib/stripe_mock/request_handlers/promotion_codes.rb
+++ b/lib/stripe_mock/request_handlers/promotion_codes.rb
@@ -36,7 +36,15 @@ module StripeMock
       end
 
       def list_promotion_code(route, method_url, params, headers)
-        Data.mock_list_object(promotion_codes.values, params)
+        promotion_code_data = promotion_codes.values
+
+        if params.key?(:code)
+          promotion_code_data.select! do |promotion_code|
+            params[:code] == promotion_code[:code]
+          end
+        end
+
+        Data.mock_list_object(promotion_code_data, params)
       end
     end
   end

--- a/spec/shared_stripe_examples/promotion_code_examples.rb
+++ b/spec/shared_stripe_examples/promotion_code_examples.rb
@@ -65,4 +65,21 @@ shared_examples "PromotionCode API" do
     expect(all.count).to eq(2)
     expect(all.map(&:code)).to include("10PERCENT", "20PERCENT")
   end
+
+  it "retrieves promotion codes with codes" do
+    promotion_codes = [
+      Stripe::PromotionCode.create({ coupon: coupon.id, code: '10PERCENT' }),
+      Stripe::PromotionCode.create({ coupon: coupon.id, code: '20PERCENT' }),
+    ]
+
+    one = Stripe::PromotionCode.list({ code: '10PERCENT' })
+    expect(one.count).to eq(1)
+    expect(one.map(&:id)).to include promotion_codes[0].id
+    expect(one.map(&:code)).to all(eq '10PERCENT')
+
+    two = Stripe::PromotionCode.list({ code: '20PERCENT' })
+    expect(two.count).to eq(1)
+    expect(two.map(&:id)).to include promotion_codes[1].id
+    expect(two.map(&:code)).to all(eq '20PERCENT')
+  end
 end


### PR DESCRIPTION
The Stripe API accepts a code param when listing promotion codes, and only returns promotion codes with that code. The comparison is case-insensitive.

Implement the code filter for the PromotionCode list endpoint.