### PR TITLE
Add case-insenstive code filter to PromotionCode list handler

### DIFF
--- a/lib/stripe_mock/request_handlers/promotion_codes.rb
+++ b/lib/stripe_mock/request_handlers/promotion_codes.rb
@@ -36,7 +36,13 @@ module StripeMock
       end
 
       def list_promotion_code(route, method_url, params, headers)
-        Data.mock_list_object(promotion_codes.values, params)
+        promotion_code_data = promotion_codes.values
+
+        if params.key?(:code)
+          promotion_code_data.select! { |promotion_code| params[:code].downcase == promotion_code[:code].downcase }
+        end
+
+        Data.mock_list_object(promotion_code_data, params)
       end
     end
   end

--- a/spec/shared_stripe_examples/promotion_code_examples.rb
+++ b/spec/shared_stripe_examples/promotion_code_examples.rb
@@ -65,4 +65,20 @@ shared_examples "PromotionCode API" do
     expect(all.count).to eq(2)
     expect(all.map(&:code)).to include("10PERCENT", "20PERCENT")
   end
+
+  it 'lists promotion codes filtering by case-insensitive code' do
+    Stripe::PromotionCode.create({ coupon: coupon.id, code: '10PERCENT' })
+    Stripe::PromotionCode.create({ coupon: coupon.id, code: '20PERCENT' })
+
+    all = Stripe::PromotionCode.list
+    expect(all.count).to eq 2
+
+    one = Stripe::PromotionCode.list({ code: '10PERCENT' })
+    expect(one.count).to eq 1
+    expect(one.map(&:code)).to include('10PERCENT')
+
+    two = Stripe::PromotionCode.list({ code: '20percent' })
+    expect(two.count).to eq 1
+    expect(two.map(&:code)).to include('20PERCENT')
+  end
 end


### PR DESCRIPTION
The Stripe PromotionCode list API supports a `code` param which returns only "promotion codes that have this case-insensitive code." (https://docs.stripe.com/api/promotion_codes/list)

This change adds a filter to the PromotionCode list handler to mimic this Stripe API behavior.