### PR TITLE
Align mock charge fields with real Stripe API response

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -321,6 +321,7 @@ module StripeMock
         amount_refunded: 0,
         customer: nil,
         invoice: nil,
+        order: nil,
         description: nil,
         dispute: nil,
         disputed: false,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -276,7 +276,7 @@ module StripeMock
         receipt_url: "https://pay.stripe.com/receipts/test_#{charge_id}",
         refunded: false,
         review: nil,
-        shipping: {},
+        shipping: nil,
         source_transfer: nil,
         statement_descriptor: nil,
         statement_descriptor_suffix: nil,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -315,6 +315,7 @@ module StripeMock
         },
         transfer: nil,
         balance_transaction: params[:balance_transaction] || "txn_2dyYXXP90MN26R",
+        failure_balance_transaction: nil,
         failure_message: nil,
         failure_code: nil,
         amount_refunded: 0,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -220,6 +220,7 @@ module StripeMock
         livemode: false,
         paid: true,
         amount: 0,
+        amount_captured: params.has_key?(:capture) && !params[:capture] ? 0 : (params[:amount] || 0),
         application_fee: nil,
         application_fee_amount: nil,
         currency: currency,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -234,7 +234,8 @@ module StripeMock
           },
           email: nil,
           name: nil,
-          phone: nil
+          phone: nil,
+          tax_id: nil
         },
         calculated_statement_descriptor: nil,
         currency: currency,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -291,6 +291,9 @@ module StripeMock
         invoice: nil,
         description: nil,
         dispute: nil,
+        disputed: false,
+        payment_intent: nil,
+        payment_method: nil,
         metadata: {
         }
       }.merge(params)

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -237,7 +237,7 @@ module StripeMock
           phone: nil,
           tax_id: nil
         },
-        calculated_statement_descriptor: nil,
+        calculated_statement_descriptor: "Stripe",
         currency: currency,
         destination: nil,
         fraud_details: {},

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -223,6 +223,20 @@ module StripeMock
         amount_captured: params.has_key?(:capture) && !params[:capture] ? 0 : (params[:amount] || 0),
         application_fee: nil,
         application_fee_amount: nil,
+        billing_details: {
+          address: {
+            city: nil,
+            country: nil,
+            line1: nil,
+            line2: nil,
+            postal_code: nil,
+            state: nil
+          },
+          email: nil,
+          name: nil,
+          phone: nil
+        },
+        calculated_statement_descriptor: nil,
         currency: currency,
         destination: nil,
         fraud_details: {},

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -278,7 +278,7 @@ module StripeMock
         review: nil,
         shipping: {},
         source_transfer: nil,
-        statement_descriptor: "Charge #{charge_id}",
+        statement_descriptor: nil,
         statement_descriptor_suffix: nil,
         status: 'succeeded',
         source: {

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -239,7 +239,6 @@ module StripeMock
         calculated_statement_descriptor: nil,
         currency: currency,
         destination: nil,
-        disputed: false,
         fraud_details: {},
         payment_method_details: {
           card: {

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -264,6 +264,9 @@ module StripeMock
         },
         on_behalf_of: nil,
         outcome: {
+          advice_code: nil,
+          network_advice_code: nil,
+          network_decline_code: nil,
           network_status: "approved_by_network",
           reason: nil,
           risk_level: "normal",

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -239,6 +239,7 @@ module StripeMock
         calculated_statement_descriptor: nil,
         currency: currency,
         destination: nil,
+        disputed: false,
         fraud_details: {},
         payment_method_details: {
           card: {
@@ -261,12 +262,24 @@ module StripeMock
           },
           type: "card"
         },
+        on_behalf_of: nil,
+        outcome: {
+          network_status: "approved_by_network",
+          reason: nil,
+          risk_level: "normal",
+          risk_score: 0,
+          seller_message: "Payment complete.",
+          type: "authorized"
+        },
         receipt_email: nil,
         receipt_number: nil,
-        receipt_url: nil,
+        receipt_url: "https://pay.stripe.com/receipts/test_#{charge_id}",
         refunded: false,
+        review: nil,
         shipping: {},
+        source_transfer: nil,
         statement_descriptor: "Charge #{charge_id}",
+        statement_descriptor_suffix: nil,
         status: 'succeeded',
         source: {
           object: "card",

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -327,6 +327,8 @@ module StripeMock
         disputed: false,
         payment_intent: nil,
         payment_method: nil,
+        transfer_data: nil,
+        transfer_group: nil,
         metadata: {
         }
       }.merge(params)

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -53,7 +53,8 @@ module StripeMock
 
         charges[id] = Data.mock_charge(
             params.merge :id => id,
-            :balance_transaction => balance_transaction_id)
+            :balance_transaction => balance_transaction_id,
+            :payment_method => params[:payment_method] || new_id('pm'))
 
         charge = charges[id].clone
         if params[:expand] == ['balance_transaction']

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -195,6 +195,8 @@ module StripeMock
            params[:payment_method_details][:card].has_key?(:checks) && params[:payment_method_details][:card][:checks].empty?))
           allowed << :payment_method_details
         end
+        allowed << :billing_details if params.has_key?(:billing_details)
+        allowed << :calculated_statement_descriptor if params.has_key?(:calculated_statement_descriptor)
 
         allowed
       end

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -197,6 +197,12 @@ module StripeMock
         end
         allowed << :billing_details if params.has_key?(:billing_details)
         allowed << :calculated_statement_descriptor if params.has_key?(:calculated_statement_descriptor)
+        allowed << :outcome if params.has_key?(:outcome) && (params[:outcome].nil? || params[:outcome].empty?)
+        allowed << :on_behalf_of if params.has_key?(:on_behalf_of)
+        allowed << :review if params.has_key?(:review)
+        allowed << :source_transfer if params.has_key?(:source_transfer)
+        allowed << :statement_descriptor_suffix if params.has_key?(:statement_descriptor_suffix)
+        allowed << :receipt_url if params.has_key?(:receipt_url)
 
         allowed
       end

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -73,6 +73,10 @@ shared_examples 'Charge API' do
     expect(charge.description).to eq('card charge')
     expect(charge.captured).to eq(true)
     expect(charge.status).to eq('succeeded')
+    expect(charge.billing_details.address.city).to be_nil
+    expect(charge.billing_details.email).to be_nil
+    expect(charge.billing_details.name).to be_nil
+    expect(charge.billing_details.phone).to be_nil
   end
 
   it "creates a stripe charge item with a bank token" do

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -84,6 +84,7 @@ shared_examples 'Charge API' do
     expect(charge.outcome.risk_level).to eq('normal')
     expect(charge.payment_method).to match(/^test_pm/)
     expect(charge.receipt_url).to include('https://pay.stripe.com/receipts/')
+    expect(charge.calculated_statement_descriptor).to eq('Stripe')
     expect(charge.statement_descriptor).to be_nil
   end
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -85,6 +85,7 @@ shared_examples 'Charge API' do
     expect(charge.outcome.type).to eq('authorized')
     expect(charge.outcome.seller_message).to eq('Payment complete.')
     expect(charge.outcome.risk_level).to eq('normal')
+    expect(charge.failure_balance_transaction).to be_nil
     expect(charge.payment_method).to match(/^test_pm/)
     expect(charge.receipt_url).to include('https://pay.stripe.com/receipts/')
     expect(charge.calculated_statement_descriptor).to eq('Stripe')

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -81,6 +81,9 @@ shared_examples 'Charge API' do
     expect(charge.outcome.type).to eq('authorized')
     expect(charge.outcome.seller_message).to eq('Payment complete.')
     expect(charge.outcome.risk_level).to eq('normal')
+    expect(charge.payment_method).to match(/^test_pm/)
+    expect(charge.receipt_url).to include('https://pay.stripe.com/receipts/')
+    expect(charge.statement_descriptor).to be_nil
   end
 
   it "creates a stripe charge item with a bank token" do

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -92,6 +92,8 @@ shared_examples 'Charge API' do
     expect(charge.calculated_statement_descriptor).to eq('Stripe')
     expect(charge.shipping).to be_nil
     expect(charge.statement_descriptor).to be_nil
+    expect(charge.transfer_data).to be_nil
+    expect(charge.transfer_group).to be_nil
   end
 
   it "creates a stripe charge item with a bank token" do

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -85,6 +85,7 @@ shared_examples 'Charge API' do
     expect(charge.payment_method).to match(/^test_pm/)
     expect(charge.receipt_url).to include('https://pay.stripe.com/receipts/')
     expect(charge.calculated_statement_descriptor).to eq('Stripe')
+    expect(charge.shipping).to be_nil
     expect(charge.statement_descriptor).to be_nil
   end
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -77,6 +77,10 @@ shared_examples 'Charge API' do
     expect(charge.billing_details.email).to be_nil
     expect(charge.billing_details.name).to be_nil
     expect(charge.billing_details.phone).to be_nil
+    expect(charge.outcome.network_status).to eq('approved_by_network')
+    expect(charge.outcome.type).to eq('authorized')
+    expect(charge.outcome.seller_message).to eq('Payment complete.')
+    expect(charge.outcome.risk_level).to eq('normal')
   end
 
   it "creates a stripe charge item with a bank token" do

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -78,6 +78,9 @@ shared_examples 'Charge API' do
     expect(charge.billing_details.name).to be_nil
     expect(charge.billing_details.phone).to be_nil
     expect(charge.billing_details.tax_id).to be_nil
+    expect(charge.outcome.advice_code).to be_nil
+    expect(charge.outcome.network_advice_code).to be_nil
+    expect(charge.outcome.network_decline_code).to be_nil
     expect(charge.outcome.network_status).to eq('approved_by_network')
     expect(charge.outcome.type).to eq('authorized')
     expect(charge.outcome.seller_message).to eq('Payment complete.')

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -86,6 +86,7 @@ shared_examples 'Charge API' do
     expect(charge.outcome.seller_message).to eq('Payment complete.')
     expect(charge.outcome.risk_level).to eq('normal')
     expect(charge.failure_balance_transaction).to be_nil
+    expect(charge.order).to be_nil
     expect(charge.payment_method).to match(/^test_pm/)
     expect(charge.receipt_url).to include('https://pay.stripe.com/receipts/')
     expect(charge.calculated_statement_descriptor).to eq('Stripe')

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -69,6 +69,7 @@ shared_examples 'Charge API' do
 
     expect(charge.id).to match(/^test_ch/)
     expect(charge.amount).to eq(999)
+    expect(charge.amount_captured).to eq(999)
     expect(charge.description).to eq('card charge')
     expect(charge.captured).to eq(true)
     expect(charge.status).to eq('succeeded')

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -77,6 +77,7 @@ shared_examples 'Charge API' do
     expect(charge.billing_details.email).to be_nil
     expect(charge.billing_details.name).to be_nil
     expect(charge.billing_details.phone).to be_nil
+    expect(charge.billing_details.tax_id).to be_nil
     expect(charge.outcome.network_status).to eq('approved_by_network')
     expect(charge.outcome.type).to eq('authorized')
     expect(charge.outcome.seller_message).to eq('Payment complete.')


### PR DESCRIPTION
## Summary

- Use Stripe API (2020-08-27) for this PR
  - Reasons
    - Some API is specified `response = Stripe::Charge.search({query: 'amount:100'}, stripe_version: '2020-08-27')`
    - all of `lib/stripe_mock/webhook_fixtures/` is specified `2020-08-27`
  - I'm going to support multiple API version from 2020-08-27 to 2025-02-24.acacia (which is the current default in Stripe ruby SDK v13) later PRs
- Add missing fields to mock charge data (`billing_details`, `outcome`, `amount_captured`, `calculated_statement_descriptor`, `failure_balance_transaction`, `payment_intent`, `payment_method`, `disputed`, `order`, `transfer_data`, `transfer_group`, `on_behalf_of`, `review`, `source_transfer`, `statement_descriptor_suffix`, `receipt_url`)
- Fix default values to match real Stripe API responses (`shipping: nil`, `statement_descriptor: nil`, `receipt_url` with test URL pattern)
- Generate `payment_method` ID (`pm_*`) when creating a charge
- Add spec coverage for newly added fields

## Test plan
- [x] Existing specs pass
- [x] New assertions added for all new fields in charge creation spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)