### PR TITLE
Add ruby 3.4 to the test matrix

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         gemfile: ["stripe_6", "stripe_7", "stripe_8", "stripe_9", "stripe_10", "stripe_11", "stripe_12", "stripe_13"]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
I've run into some warnings running this gem on ruby 3.4. But before I try fixing any of them, I think it's best to start testing ruby 3.4 in CI.