### PR TITLE
Remove unused require 'ostruct'

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'multi_json'
 require 'dante'
 require 'time'


### PR DESCRIPTION
The require was added in c34c4e8 (2013) but was apparently never used.

Removing it silences the Ruby 3.4 bundled-gem deprecation warning ("ostruct was loaded from the standard library, but will no longer be part of the default gems") without needing to add ostruct as a dependency.