### PR TITLE
Avoid repeatedly starting client-side DRb servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,6 @@ Patches are welcome and greatly appreciated! If you're contributing to fix a pro
 be sure to write tests that illustrate the problem being fixed.
 This will help ensure that the problem remains fixed in future updates.
 
-Note: You may need to `ulimit -n 4048` before running the test suite to get all tests to pass.
-
 ### Dependency updates
 
 When modifications are made to dependencies in addition to the changes to the Gemfile, Gemfile.lock and stripe-ruby-mock.gemspec you must also run `bundle exec appraisal update` to update the gemfiles specific to Stripe version 12 and Stripe version 13.

--- a/lib/stripe_mock/client.rb
+++ b/lib/stripe_mock/client.rb
@@ -5,7 +5,7 @@ module StripeMock
     def initialize(port)
       @port = port
 
-      DRb.start_service
+      DRb.start_service unless DRb.primary_server
       @pipe = DRbObject.new_with_uri "druby://localhost:#{port}"
 
       # Ensure client can connect to server


### PR DESCRIPTION
The DRb server needs to be running once client-side, but it holds no state and so doesn't need to be restarted. The same service is process-wide and can be used to talk with multiple backend DRb servers.

`DRb.start_service` replaces the `primary_server` each time it is called, orphaning the previous one as it does so. This leads to fd leaks if `StripeMock.start_client` and `StripeMock.stop_client` are called repeatedly, such as when running the test suite.

An alternative approach would be to stop the service during `stop_client`, but this would interfere with any other code in the same process that's using the DRb.