### PR TITLE
Fix duplicate "status" key in verified bank account data

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/bank_account_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/bank_account_helpers.rb
@@ -6,7 +6,7 @@ module StripeMock
         bank_accounts = object[:external_accounts] || object[:bank_accounts] || object[:sources]
         bank_account = bank_accounts[:data].find{|acc| acc[:id] == bank_account_id }
         return if bank_account.nil?
-        bank_account['status'] = 'verified'
+        bank_account[:status] = 'verified'
         bank_account
       end
     end


### PR DESCRIPTION
Elsewhere in the code the symbol key `:status` is used, and this mismatch is flagged up as a warning when using ruby 4.0