### PR TITLE
Add ruby 4.0 to CI matrix

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
         gemfile: ["stripe_6", "stripe_7", "stripe_8", "stripe_9", "stripe_10", "stripe_11", "stripe_12", "stripe_13"]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/gemfiles/stripe_10.gemfile.lock
+++ b/gemfiles/stripe_10.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.19.1)
     rack (2.2.22)
     rake (13.3.1)

--- a/gemfiles/stripe_11.gemfile.lock
+++ b/gemfiles/stripe_11.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.19.1)
     rack (2.2.22)
     rake (13.3.1)

--- a/gemfiles/stripe_12.gemfile.lock
+++ b/gemfiles/stripe_12.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (2.8.1)
     drb (2.2.1)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.15.0)
     rack (2.2.13)
     rake (13.2.1)

--- a/gemfiles/stripe_13.gemfile.lock
+++ b/gemfiles/stripe_13.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (2.8.1)
     drb (2.2.1)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.15.0)
     rack (2.2.13)
     rake (13.2.1)

--- a/gemfiles/stripe_6.gemfile.lock
+++ b/gemfiles/stripe_6.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.19.1)
     rack (2.2.22)
     rake (13.3.1)

--- a/gemfiles/stripe_7.gemfile.lock
+++ b/gemfiles/stripe_7.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.19.1)
     rack (2.2.22)
     rake (13.3.1)

--- a/gemfiles/stripe_8.gemfile.lock
+++ b/gemfiles/stripe_8.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.19.1)
     rack (2.2.22)
     rake (13.3.1)

--- a/gemfiles/stripe_9.gemfile.lock
+++ b/gemfiles/stripe_9.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stripe-ruby-mock (5.0.0)
       dante (>= 0.2.0)
       drb (>= 2.0.4, < 3)
+      logger
       multi_json (~> 1.0)
       stripe (> 5, < 14)
 
@@ -20,6 +21,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     eventmachine (1.2.7)
+    logger (1.7.0)
     multi_json (1.19.1)
     rack (2.2.22)
     rake (13.3.1)

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'stripe', '> 5', '< 14'
+  # logger is a dependency of stripe, but was removed from the
+  # default gems in ruby 4 and only added explicitly to stripe in v19.
+  gem.add_dependency 'logger'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
   gem.add_dependency 'drb', '>= 2.0.4', '< 3'


### PR DESCRIPTION
Everything works fine on ruby 4, the only thing that needed fixing was the logger dependency for the stripe gem. 

We can remove this line from the gemspec when we remove support for `stripe < 19` - which might be a while! :smile: 