### PR TITLE
Fix various timing flakes in CI

### DIFF
--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -603,7 +603,7 @@ shared_examples 'Customer Subscriptions with plans' do
         ]
       )
 
-      expect(subscription.current_period_end).to eq (Time.now + (7 * 60 * 60 * 24)).to_i
+      expect(subscription.current_period_end).to be_within(2).of((Time.now + (7 * 60 * 60 * 24)).to_i)
     end
 
     it 'sets current_period_end based on price month interval', live: true do
@@ -616,7 +616,7 @@ shared_examples 'Customer Subscriptions with plans' do
         ]
       )
 
-      expect(subscription.current_period_end).to eq (DateTime.now >> 1).to_time.to_i
+      expect(subscription.current_period_end).to be_within(2).of((DateTime.now >> 1).to_time.to_i)
     end
 
     it 'sets current_period_end based on price year interval', live: true do
@@ -629,7 +629,7 @@ shared_examples 'Customer Subscriptions with plans' do
         ]
       )
 
-      expect(subscription.current_period_end).to eq (DateTime.now >> 12).to_time.to_i
+      expect(subscription.current_period_end).to be_within(2).of((DateTime.now >> 12).to_time.to_i)
     end
 
     it 'add a new subscription to bill via an invoice' do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1449,8 +1449,13 @@ shared_examples 'Customer Subscriptions with plans' do
       list = Stripe::Subscription.list({ current_period_end: { lte: subscription1.current_period_end }})
       expect(list.data).to contain_exactly(subscription1)
 
+      # subscription1 and subscription2 are created moments apart, so in some test runs have
+      # slightly different start times. Query by each start time in case they are different.
       list = Stripe::Subscription.list({ current_period_start: subscription1.current_period_start })
-      expect(list.data).to contain_exactly(subscription1, subscription2)
+      expect(list.data).to include(subscription1)
+
+      list = Stripe::Subscription.list({ current_period_start: subscription2.current_period_start })
+      expect(list.data).to include(subscription2)
 
       list = Stripe::Subscription.list({ current_period_end: subscription2.current_period_end })
       expect(list.data).to contain_exactly(subscription2)


### PR DESCRIPTION
This PR cherry-picks three timing fixes that are included in #948 , and adds another fix for a separate timing issue. This will make CI more reliable.

I've run into these a few times, e.g. the CI failures in #965 and #964, and I've seen the same failures happen in CI for master before too (e.g. https://github.com/stripe-ruby-mock/stripe-ruby-mock/actions/runs/23853321938/job/69539297345 )