### PR TITLE
Add missing appraisals configuration

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,3 +5,27 @@ end
 appraise "stripe-12" do
   gem "stripe", "12.6.0"
 end
+
+appraise "stripe-11" do
+  gem "stripe", "11.7.0"
+end
+
+appraise "stripe-10" do
+  gem "stripe", "10.15.0"
+end
+
+appraise "stripe-9" do
+  gem "stripe", "9.4.0"
+end
+
+appraise "stripe-8" do
+  gem "stripe", "8.7.0"
+end
+
+appraise "stripe-7" do
+  gem "stripe", "7.1.0"
+end
+
+appraise "stripe-6" do
+  gem "stripe", "6.5.0"
+end

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ This will help ensure that the problem remains fixed in future updates.
 
 ### Dependency updates
 
-When modifications are made to dependencies in addition to the changes to the Gemfile, Gemfile.lock and stripe-ruby-mock.gemspec you must also run `bundle exec appraisal update` to update the gemfiles specific to Stripe version 12 and Stripe version 13.
+When modifications are made to dependencies, in addition to the changes to the Gemfile, Gemfile.lock and stripe-ruby-mock.gemspec you must also run `bundle exec appraisal update` to update the various gemfiles that are specific to the supported Stripe versions.
 
 ## Copyright
 


### PR DESCRIPTION
PR #958 added the Gemfiles for Stripe v6-11, but didn't add the Appraisals configuration. This means that these Gemfiles won't be updated when running `bundle exec appraisal update`

I spotted this while trying to help get CI to go green in #967 